### PR TITLE
feat: configurable logging levels and file-based log output

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -4,7 +4,9 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"strings"
@@ -17,6 +19,7 @@ import (
 
 	"github.com/tamcore/kubectl-mcp/internal/config"
 	"github.com/tamcore/kubectl-mcp/internal/kube"
+	"github.com/tamcore/kubectl-mcp/internal/mcplog"
 	"github.com/tamcore/kubectl-mcp/internal/resources"
 	"github.com/tamcore/kubectl-mcp/internal/tools"
 )
@@ -50,10 +53,17 @@ func startSSEServerWithConfig(t *testing.T, cfg *config.Config) string {
 		t.Fatalf("NewClientPool: %v", err)
 	}
 
-	s := server.NewMCPServer("kubectl-mcp-e2e", "test",
+	var s *server.MCPServer
+	opts := []server.ServerOption{
 		server.WithToolCapabilities(false),
 		server.WithResourceCapabilities(false, false),
-	)
+	}
+	hooks := buildE2ELoggingHooks(t, &s, cfg)
+	if hooks != nil {
+		opts = append(opts, server.WithLogging(), server.WithHooks(hooks))
+	}
+
+	s = server.NewMCPServer("kubectl-mcp-e2e", "test", opts...)
 	tools.RegisterAll(s, pool, cfg)
 	resources.RegisterAll(s, pool, cfg)
 
@@ -102,10 +112,17 @@ func startStreamableHTTPServerWithConfig(t *testing.T, cfg *config.Config) strin
 		t.Fatalf("NewClientPool: %v", err)
 	}
 
-	s := server.NewMCPServer("kubectl-mcp-e2e", "test",
+	var s *server.MCPServer
+	opts := []server.ServerOption{
 		server.WithToolCapabilities(false),
 		server.WithResourceCapabilities(false, false),
-	)
+	}
+	hooks := buildE2ELoggingHooks(t, &s, cfg)
+	if hooks != nil {
+		opts = append(opts, server.WithLogging(), server.WithHooks(hooks))
+	}
+
+	s = server.NewMCPServer("kubectl-mcp-e2e", "test", opts...)
 	tools.RegisterAll(s, pool, cfg)
 	resources.RegisterAll(s, pool, cfg)
 
@@ -263,4 +280,89 @@ type transportCase struct {
 var allTransports = []transportCase{
 	{"SSE", startSSEServerWithConfig, newSSEClient},
 	{"HTTP", startStreamableHTTPServerWithConfig, newHTTPClient},
+}
+
+// ---------------------------------------------------------------------------
+// Logging hooks for E2E (mirrors internal/cmd/serve.go logic)
+// ---------------------------------------------------------------------------
+
+// buildE2ELoggingHooks creates logging hooks for E2E tests matching the
+// given config's LogLevel. Returns nil for empty/unset levels.
+func buildE2ELoggingHooks(t *testing.T, sPtr **server.MCPServer, cfg *config.Config) *server.Hooks {
+	t.Helper()
+
+	if cfg.LogLevel == "" {
+		return nil
+	}
+
+	level, err := mcplog.ParseLogLevel(cfg.LogLevel)
+	if err != nil {
+		t.Fatalf("invalid log level %q: %v", cfg.LogLevel, err)
+	}
+
+	hooks := &server.Hooks{}
+	if level == mcplog.LogLevelOff {
+		return hooks
+	}
+
+	logger := log.New(os.Stderr, "e2e: ", 0)
+
+	hooks.AddBeforeCallTool(func(ctx context.Context, id any, req *mcp.CallToolRequest) {
+		args := summarizeToolArgs(req.GetArguments())
+		logger.Printf("→ %s(%s)", req.Params.Name, args)
+
+		if level == mcplog.LogLevelDebug && *sPtr != nil {
+			_ = (*sPtr).SendLogMessageToClient(ctx, mcplog.NewNotification(
+				mcp.LoggingLevelDebug,
+				fmt.Sprintf("→ %s(%s)", req.Params.Name, args),
+			))
+		}
+	})
+
+	hooks.AddAfterCallTool(func(ctx context.Context, id any, req *mcp.CallToolRequest, result any) {
+		r, ok := result.(*mcp.CallToolResult)
+		if !ok {
+			return
+		}
+
+		if r.IsError {
+			logger.Printf("✗ %s failed", req.Params.Name)
+			if *sPtr != nil {
+				_ = (*sPtr).SendLogMessageToClient(ctx, mcplog.NewNotification(
+					mcp.LoggingLevelWarning,
+					fmt.Sprintf("%s failed", req.Params.Name),
+				))
+			}
+			return
+		}
+
+		if level == mcplog.LogLevelDebug && *sPtr != nil {
+			_ = (*sPtr).SendLogMessageToClient(ctx, mcplog.NewNotification(
+				mcp.LoggingLevelDebug,
+				fmt.Sprintf("✓ %s done", req.Params.Name),
+			))
+		}
+		logger.Printf("✓ %s done", req.Params.Name)
+	})
+
+	return hooks
+}
+
+func summarizeToolArgs(args map[string]any) string {
+	if len(args) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(args)
+	if err != nil {
+		return "..."
+	}
+	s := string(b)
+	if len(s) > 2 {
+		s = s[1 : len(s)-1]
+	}
+	const maxLen = 120
+	if len(s) > maxLen {
+		s = s[:maxLen] + "…"
+	}
+	return s
 }

--- a/e2e/log_level_test.go
+++ b/e2e/log_level_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -31,6 +32,9 @@ func TestLogLevel(t *testing.T) {
 				if result.IsError {
 					t.Fatalf("list_contexts failed: %s", resultText(result))
 				}
+
+				// Brief wait so any late async notifications arrive.
+				time.Sleep(200 * time.Millisecond)
 
 				mu.Lock()
 				logNotifs := filterLogNotifications(notifications)
@@ -60,6 +64,9 @@ func TestLogLevel(t *testing.T) {
 				if result.IsError {
 					t.Fatalf("list_contexts failed: %s", resultText(result))
 				}
+
+				// Brief wait so any late async notifications arrive.
+				time.Sleep(200 * time.Millisecond)
 
 				mu.Lock()
 				logNotifs := filterLogNotifications(notifications)
@@ -93,9 +100,18 @@ func TestLogLevel(t *testing.T) {
 					t.Fatalf("list_contexts failed: %s", resultText(result))
 				}
 
-				mu.Lock()
-				logNotifs := filterLogNotifications(notifications)
-				mu.Unlock()
+				// Notifications arrive asynchronously; poll briefly.
+				var logNotifs []mcp.JSONRPCNotification
+				deadline := time.Now().Add(2 * time.Second)
+				for time.Now().Before(deadline) {
+					mu.Lock()
+					logNotifs = filterLogNotifications(notifications)
+					mu.Unlock()
+					if len(logNotifs) > 0 {
+						break
+					}
+					time.Sleep(50 * time.Millisecond)
+				}
 
 				if len(logNotifs) == 0 {
 					t.Error("expected logging notifications at debug level, got none")

--- a/e2e/log_level_test.go
+++ b/e2e/log_level_test.go
@@ -1,0 +1,143 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestLogLevel(t *testing.T) {
+	for _, tc := range allTransports {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("off_no_notifications", func(t *testing.T) {
+				cfg := defaultConfig()
+				cfg.LogLevel = "off"
+
+				base := tc.startFunc(t, cfg)
+				c := tc.clientFunc(t, base)
+
+				var mu sync.Mutex
+				var notifications []mcp.JSONRPCNotification
+				c.OnNotification(func(n mcp.JSONRPCNotification) {
+					mu.Lock()
+					defer mu.Unlock()
+					notifications = append(notifications, n)
+				})
+
+				result := callTool(t, c, "list_contexts", nil)
+				if result.IsError {
+					t.Fatalf("list_contexts failed: %s", resultText(result))
+				}
+
+				mu.Lock()
+				logNotifs := filterLogNotifications(notifications)
+				mu.Unlock()
+
+				if len(logNotifs) > 0 {
+					t.Errorf("expected no logging notifications at off level, got %d", len(logNotifs))
+				}
+			})
+
+			t.Run("info_no_debug_notifications", func(t *testing.T) {
+				cfg := defaultConfig()
+				cfg.LogLevel = "info"
+
+				base := tc.startFunc(t, cfg)
+				c := tc.clientFunc(t, base)
+
+				var mu sync.Mutex
+				var notifications []mcp.JSONRPCNotification
+				c.OnNotification(func(n mcp.JSONRPCNotification) {
+					mu.Lock()
+					defer mu.Unlock()
+					notifications = append(notifications, n)
+				})
+
+				result := callTool(t, c, "list_contexts", nil)
+				if result.IsError {
+					t.Fatalf("list_contexts failed: %s", resultText(result))
+				}
+
+				mu.Lock()
+				logNotifs := filterLogNotifications(notifications)
+				mu.Unlock()
+
+				for _, n := range logNotifs {
+					level := extractNotificationLevel(n)
+					if level == "debug" {
+						t.Errorf("unexpected debug notification at info level: %+v", n)
+					}
+				}
+			})
+
+			t.Run("debug_sends_notifications", func(t *testing.T) {
+				cfg := defaultConfig()
+				cfg.LogLevel = "debug"
+
+				base := tc.startFunc(t, cfg)
+				c := tc.clientFunc(t, base)
+
+				var mu sync.Mutex
+				var notifications []mcp.JSONRPCNotification
+				c.OnNotification(func(n mcp.JSONRPCNotification) {
+					mu.Lock()
+					defer mu.Unlock()
+					notifications = append(notifications, n)
+				})
+
+				result := callTool(t, c, "list_contexts", nil)
+				if result.IsError {
+					t.Fatalf("list_contexts failed: %s", resultText(result))
+				}
+
+				mu.Lock()
+				logNotifs := filterLogNotifications(notifications)
+				mu.Unlock()
+
+				if len(logNotifs) == 0 {
+					t.Error("expected logging notifications at debug level, got none")
+				}
+			})
+
+			t.Run("tools_work_at_all_levels", func(t *testing.T) {
+				for _, level := range []string{"off", "info", "debug"} {
+					t.Run(level, func(t *testing.T) {
+						cfg := defaultConfig()
+						cfg.LogLevel = level
+
+						base := tc.startFunc(t, cfg)
+						c := tc.clientFunc(t, base)
+
+						result := callTool(t, c, "list_contexts", nil)
+						if result.IsError {
+							t.Fatalf("list_contexts failed at %s level: %s", level, resultText(result))
+						}
+						if resultText(result) == "" {
+							t.Fatalf("expected non-empty result at %s level", level)
+						}
+					})
+				}
+			})
+		})
+	}
+}
+
+// filterLogNotifications returns only notifications/message notifications.
+func filterLogNotifications(notifs []mcp.JSONRPCNotification) []mcp.JSONRPCNotification {
+	var result []mcp.JSONRPCNotification
+	for _, n := range notifs {
+		if n.Method == "notifications/message" {
+			result = append(result, n)
+		}
+	}
+	return result
+}
+
+// extractNotificationLevel extracts the logging level from a notification params.
+func extractNotificationLevel(n mcp.JSONRPCNotification) string {
+	level, _ := n.Params.AdditionalFields["level"].(string)
+	return level
+}

--- a/e2e/log_level_test.go
+++ b/e2e/log_level_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -86,6 +87,14 @@ func TestLogLevel(t *testing.T) {
 
 				base := tc.startFunc(t, cfg)
 				c := tc.clientFunc(t, base)
+
+				// Tell the server we want debug-level notifications.
+				err := c.SetLevel(context.Background(), mcp.SetLevelRequest{
+					Params: mcp.SetLevelParams{Level: mcp.LoggingLevelDebug},
+				})
+				if err != nil {
+					t.Fatalf("SetLevel: %v", err)
+				}
 
 				var mu sync.Mutex
 				var notifications []mcp.JSONRPCNotification

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -46,7 +46,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&cfg.RateLimitRead, "rate-limit-read", 120, "Max read tool calls per minute (0 = unlimited)")
 	rootCmd.PersistentFlags().IntVar(&cfg.RateLimitWrite, "rate-limit-write", 30, "Max write tool calls per minute (0 = unlimited)")
 	rootCmd.PersistentFlags().StringVar(&cfg.LogLevel, "log-level", "info", "Logging verbosity: off, info, or debug")
-	rootCmd.PersistentFlags().StringVar(&cfg.LogFile, "log-file", "", "Log file path (default: ~/.kubectl-mcp/server.log)")
+	rootCmd.PersistentFlags().StringVar(&cfg.LogFile, "log-file", "", "Log file path (default: ~/.kubectl-mcp/server-<pid>.log)")
 
 	rootCmd.AddCommand(serveCmd)
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -45,6 +45,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&cfg.AllowRaw, "allow-raw", false, "Enable raw Kubernetes API requests (api_raw tool)")
 	rootCmd.PersistentFlags().IntVar(&cfg.RateLimitRead, "rate-limit-read", 120, "Max read tool calls per minute (0 = unlimited)")
 	rootCmd.PersistentFlags().IntVar(&cfg.RateLimitWrite, "rate-limit-write", 30, "Max write tool calls per minute (0 = unlimited)")
+	rootCmd.PersistentFlags().StringVar(&cfg.LogLevel, "log-level", "info", "Logging verbosity: off, info, or debug")
 
 	rootCmd.AddCommand(serveCmd)
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -46,6 +46,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&cfg.RateLimitRead, "rate-limit-read", 120, "Max read tool calls per minute (0 = unlimited)")
 	rootCmd.PersistentFlags().IntVar(&cfg.RateLimitWrite, "rate-limit-write", 30, "Max write tool calls per minute (0 = unlimited)")
 	rootCmd.PersistentFlags().StringVar(&cfg.LogLevel, "log-level", "info", "Logging verbosity: off, info, or debug")
+	rootCmd.PersistentFlags().StringVar(&cfg.LogFile, "log-file", "", "Log file path (default: ~/.kubectl-mcp/server.log)")
 
 	rootCmd.AddCommand(serveCmd)
 }

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
+	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -32,7 +34,15 @@ var serveCmd = &cobra.Command{
 
 		// Use a pointer so hooks can reference the server after creation.
 		var s *server.MCPServer
-		hooks := newLoggingHooks(&s)
+		logLevel, _ := mcplog.ParseLogLevel(cfg.LogLevel)
+		logger := log.New(os.Stderr, "", log.LstdFlags)
+		hooks := newLoggingHooks(&s, logLevel, logger)
+
+		if logLevel == mcplog.LogLevelDebug {
+			pool.SetTransportWrapper(func(rt http.RoundTripper) http.RoundTripper {
+				return mcplog.NewLoggingTransport(rt, logger)
+			})
+		}
 
 		s = server.NewMCPServer(
 			"kubectl-mcp",
@@ -65,15 +75,23 @@ var serveCmd = &cobra.Command{
 	},
 }
 
-func newLoggingHooks(sPtr **server.MCPServer) *server.Hooks {
-	logger := log.New(os.Stderr, "", log.LstdFlags)
+func newLoggingHooks(sPtr **server.MCPServer, level mcplog.LogLevel, logger *log.Logger) *server.Hooks {
 	hooks := &server.Hooks{}
 
+	if level == mcplog.LogLevelOff {
+		return hooks
+	}
+
 	hooks.AddBeforeCallTool(func(ctx context.Context, id any, req *mcp.CallToolRequest) {
-		args := summarizeArgs(req.GetArguments())
+		var args string
+		if level == mcplog.LogLevelDebug {
+			args = fullArgs(req.GetArguments())
+		} else {
+			args = summarizeArgs(req.GetArguments())
+		}
 		logger.Printf("→ %s(%s)", req.Params.Name, args)
 
-		if *sPtr != nil {
+		if level == mcplog.LogLevelDebug && *sPtr != nil {
 			_ = (*sPtr).SendLogMessageToClient(ctx, mcplog.NewNotification(
 				mcp.LoggingLevelDebug,
 				fmt.Sprintf("→ %s(%s)", req.Params.Name, args),
@@ -82,14 +100,30 @@ func newLoggingHooks(sPtr **server.MCPServer) *server.Hooks {
 	})
 
 	hooks.AddAfterCallTool(func(ctx context.Context, id any, req *mcp.CallToolRequest, result any) {
-		if r, ok := result.(*mcp.CallToolResult); ok && r.IsError {
-			logger.Printf("✗ %s failed", req.Params.Name)
+		r, ok := result.(*mcp.CallToolResult)
+		if !ok {
+			return
+		}
 
+		if r.IsError {
+			logger.Printf("✗ %s failed", req.Params.Name)
 			if *sPtr != nil {
 				errText := extractErrorText(r)
 				_ = (*sPtr).SendLogMessageToClient(ctx, mcplog.NewNotification(
 					mcp.LoggingLevelWarning,
 					fmt.Sprintf("%s failed: %s", req.Params.Name, errText),
+				))
+			}
+			return
+		}
+
+		if level == mcplog.LogLevelDebug {
+			text := extractResultText(r)
+			logger.Printf("✓ %s done (%dB)\n%s", req.Params.Name, len(text), text)
+			if *sPtr != nil {
+				_ = (*sPtr).SendLogMessageToClient(ctx, mcplog.NewNotification(
+					mcp.LoggingLevelDebug,
+					fmt.Sprintf("✓ %s result: %s", req.Params.Name, text),
 				))
 			}
 		} else {
@@ -139,4 +173,32 @@ func summarizeArgs(args map[string]any) string {
 		s = s[:maxLen] + "…"
 	}
 	return s
+}
+
+func fullArgs(args map[string]any) string {
+	if len(args) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(args)
+	if err != nil {
+		return "..."
+	}
+	s := string(b)
+	if len(s) > 2 {
+		s = s[1 : len(s)-1]
+	}
+	return s
+}
+
+func extractResultText(r *mcp.CallToolResult) string {
+	if len(r.Content) == 0 {
+		return ""
+	}
+	var parts []string
+	for _, c := range r.Content {
+		if tc, ok := c.(mcp.TextContent); ok {
+			parts = append(parts, tc.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
 }

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -35,7 +36,19 @@ var serveCmd = &cobra.Command{
 		// Use a pointer so hooks can reference the server after creation.
 		var s *server.MCPServer
 		logLevel, _ := mcplog.ParseLogLevel(cfg.LogLevel)
-		logger := log.New(os.Stderr, "", log.LstdFlags)
+
+		// Set up file-based logger (skip when logging is off).
+		var logger *log.Logger
+		if logLevel != mcplog.LogLevelOff {
+			logFile, err := openLogFile(cfg.LogFile)
+			if err != nil {
+				return fmt.Errorf("failed to open log file %q: %w", cfg.LogFile, err)
+			}
+			defer func() { _ = logFile.Close() }()
+			logger = log.New(logFile, "", log.LstdFlags)
+			logger.Printf("kubectl-mcp %s started (log-level=%s)", appVersion, logLevel)
+		}
+
 		hooks := newLoggingHooks(&s, logLevel, logger)
 
 		if logLevel == mcplog.LogLevelDebug {
@@ -201,4 +214,14 @@ func extractResultText(r *mcp.CallToolResult) string {
 		}
 	}
 	return strings.Join(parts, "\n")
+}
+
+// openLogFile creates the parent directory if needed and opens the log file
+// for appending. The caller is responsible for closing the returned file.
+func openLogFile(path string) (*os.File, error) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return nil, fmt.Errorf("creating log directory %q: %w", dir, err)
+	}
+	return os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
 }

--- a/internal/cmd/serve_test.go
+++ b/internal/cmd/serve_test.go
@@ -10,6 +10,8 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -370,5 +372,57 @@ func TestLoggingHooks_Debug(t *testing.T) {
 	}
 	if !strings.Contains(output, "apiVersion") {
 		t.Fatalf("expected result content in debug after log, got: %s", output)
+	}
+}
+
+func TestOpenLogFile_CreatesDirectoryAndFile(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "subdir", "test.log")
+
+	f, err := openLogFile(logPath)
+	if err != nil {
+		t.Fatalf("openLogFile(%q) error: %v", logPath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Write something to verify it's writable.
+	if _, err := f.WriteString("test\n"); err != nil {
+		t.Fatalf("failed to write to log file: %v", err)
+	}
+
+	// Verify the file exists.
+	info, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatalf("log file does not exist: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("log file is empty after write")
+	}
+}
+
+func TestOpenLogFile_AppendsToExisting(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "test.log")
+
+	// Create a file with existing content.
+	if err := os.WriteFile(logPath, []byte("existing\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := openLogFile(logPath)
+	if err != nil {
+		t.Fatalf("openLogFile(%q) error: %v", logPath, err)
+	}
+	if _, err := f.WriteString("new\n"); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	_ = f.Close()
+
+	content, _ := os.ReadFile(logPath)
+	if !strings.Contains(string(content), "existing") {
+		t.Fatal("existing content was overwritten")
+	}
+	if !strings.Contains(string(content), "new") {
+		t.Fatal("new content not appended")
 	}
 }

--- a/internal/cmd/serve_test.go
+++ b/internal/cmd/serve_test.go
@@ -1,11 +1,13 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"strings"
@@ -14,6 +16,8 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/tamcore/kubectl-mcp/internal/mcplog"
 )
 
 // startTestMCPServer starts a streamable-HTTP MCP server on a random port and
@@ -223,8 +227,10 @@ func TestServerInstructions_InInitializeResponse(t *testing.T) {
 }
 
 func TestNewLoggingHooks(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
 	var s *server.MCPServer
-	hooks := newLoggingHooks(&s)
+	hooks := newLoggingHooks(&s, mcplog.LogLevelInfo, logger)
 	if hooks == nil {
 		t.Fatal("newLoggingHooks() returned nil")
 	}
@@ -253,5 +259,116 @@ func TestNewLoggingHooks(t *testing.T) {
 	// Exercise OnError hook.
 	for _, fn := range hooks.OnError {
 		fn(ctx, "id-3", mcp.MethodToolsCall, nil, errors.New("boom"))
+	}
+}
+
+func TestLoggingHooks_Off(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+	var s *server.MCPServer
+	hooks := newLoggingHooks(&s, mcplog.LogLevelOff, logger)
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+	req.Params.Name = "get_resource"
+	req.Params.Arguments = map[string]any{"kind": "Pod", "name": "nginx"}
+
+	for _, fn := range hooks.OnBeforeCallTool {
+		fn(ctx, "id-1", req)
+	}
+	result := &mcp.CallToolResult{IsError: false}
+	for _, fn := range hooks.OnAfterCallTool {
+		fn(ctx, "id-1", req, result)
+	}
+	for _, fn := range hooks.OnError {
+		fn(ctx, "id-2", mcp.MethodToolsCall, nil, errors.New("boom"))
+	}
+
+	if buf.Len() > 0 {
+		t.Fatalf("expected no log output at off level, got: %s", buf.String())
+	}
+}
+
+func TestLoggingHooks_Info(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+	var s *server.MCPServer
+	hooks := newLoggingHooks(&s, mcplog.LogLevelInfo, logger)
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+	req.Params.Name = "get_resource"
+	req.Params.Arguments = map[string]any{"kind": "Pod", "name": "nginx"}
+
+	// Before hook should log tool name + summarized args.
+	for _, fn := range hooks.OnBeforeCallTool {
+		fn(ctx, "id-1", req)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "get_resource") {
+		t.Fatalf("expected tool name in log, got: %s", output)
+	}
+
+	// After hook should log success.
+	buf.Reset()
+	result := &mcp.CallToolResult{IsError: false}
+	for _, fn := range hooks.OnAfterCallTool {
+		fn(ctx, "id-1", req, result)
+	}
+	output = buf.String()
+	if !strings.Contains(output, "✓") || !strings.Contains(output, "get_resource") {
+		t.Fatalf("expected success marker in log, got: %s", output)
+	}
+
+	// After hook should log failure.
+	buf.Reset()
+	errorResult := &mcp.CallToolResult{
+		IsError: true,
+		Content: []mcp.Content{mcp.NewTextContent("not found")},
+	}
+	for _, fn := range hooks.OnAfterCallTool {
+		fn(ctx, "id-2", req, errorResult)
+	}
+	output = buf.String()
+	if !strings.Contains(output, "✗") {
+		t.Fatalf("expected failure marker in log, got: %s", output)
+	}
+}
+
+func TestLoggingHooks_Debug(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+	var s *server.MCPServer
+	hooks := newLoggingHooks(&s, mcplog.LogLevelDebug, logger)
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+	req.Params.Name = "get_resource"
+	req.Params.Arguments = map[string]any{"kind": "Pod", "name": "nginx", "namespace": "default"}
+
+	// Before hook should log full (unsummarized) args.
+	for _, fn := range hooks.OnBeforeCallTool {
+		fn(ctx, "id-1", req)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "get_resource") {
+		t.Fatalf("expected tool name in debug log, got: %s", output)
+	}
+
+	// After hook should log full result text.
+	buf.Reset()
+	result := &mcp.CallToolResult{
+		IsError: false,
+		Content: []mcp.Content{mcp.NewTextContent(`{"apiVersion":"v1","kind":"Pod"}`)},
+	}
+	for _, fn := range hooks.OnAfterCallTool {
+		fn(ctx, "id-1", req, result)
+	}
+	output = buf.String()
+	if !strings.Contains(output, "get_resource") {
+		t.Fatalf("expected tool name in debug after log, got: %s", output)
+	}
+	if !strings.Contains(output, "apiVersion") {
+		t.Fatalf("expected result content in debug after log, got: %s", output)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/tamcore/kubectl-mcp/internal/mcplog"
 )
 
 // Config holds all runtime configuration for the MCP server.
@@ -23,6 +25,7 @@ type Config struct {
 	AllowRaw         bool
 	RateLimitRead    int
 	RateLimitWrite   int
+	LogLevel         string
 }
 
 // Validate checks the configuration for consistency.
@@ -34,6 +37,12 @@ func (c *Config) Validate() error {
 	}
 	if c.AllowDestructive {
 		c.AllowWrite = true
+	}
+	if c.LogLevel == "" {
+		c.LogLevel = "info"
+	}
+	if _, err := mcplog.ParseLogLevel(c.LogLevel); err != nil {
+		return err
 	}
 	if c.RateLimitRead < 0 {
 		return fmt.Errorf("invalid rate-limit-read %d: must be >= 0 (0 = unlimited)", c.RateLimitRead)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	RateLimitRead    int
 	RateLimitWrite   int
 	LogLevel         string
+	LogFile          string
 }
 
 // Validate checks the configuration for consistency.
@@ -43,6 +44,9 @@ func (c *Config) Validate() error {
 	}
 	if _, err := mcplog.ParseLogLevel(c.LogLevel); err != nil {
 		return err
+	}
+	if c.LogLevel != "off" && c.LogFile == "" {
+		c.LogFile = mcplog.DefaultLogPath()
 	}
 	if c.RateLimitRead < 0 {
 		return fmt.Errorf("invalid rate-limit-read %d: must be >= 0 (0 = unlimited)", c.RateLimitRead)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -323,6 +323,48 @@ func TestMatchesAny(t *testing.T) {
 	}
 }
 
+func TestValidate_LogLevel(t *testing.T) {
+	tests := []struct {
+		name     string
+		logLevel string
+		wantErr  string
+	}{
+		{"off is valid", "off", ""},
+		{"info is valid", "info", ""},
+		{"debug is valid", "debug", ""},
+		{"empty defaults to info", "", ""},
+		{"invalid level", "trace", "invalid log level"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{Transport: "stdio", LogLevel: tt.logLevel}
+			err := c.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("got %q, want error containing %q", err.Error(), tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestValidate_LogLevel_DefaultsToInfo(t *testing.T) {
+	c := &Config{Transport: "stdio"}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.LogLevel != "info" {
+		t.Fatalf("expected LogLevel to default to 'info', got %q", c.LogLevel)
+	}
+}
+
 func TestIsRegex(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -365,6 +365,37 @@ func TestValidate_LogLevel_DefaultsToInfo(t *testing.T) {
 	}
 }
 
+func TestValidate_LogFile_DefaultWhenEmpty(t *testing.T) {
+	c := &Config{Transport: "stdio", LogLevel: "info"}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.LogFile == "" {
+		t.Fatal("expected LogFile to be set to default path, got empty")
+	}
+	if !strings.Contains(c.LogFile, ".kubectl-mcp") {
+		t.Fatalf("expected default LogFile to contain .kubectl-mcp, got %q", c.LogFile)
+	}
+}
+
+func TestValidate_LogFile_PreservedWhenSet(t *testing.T) {
+	c := &Config{Transport: "stdio", LogLevel: "info", LogFile: "/tmp/custom.log"}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.LogFile != "/tmp/custom.log" {
+		t.Fatalf("expected LogFile to be preserved, got %q", c.LogFile)
+	}
+}
+
+func TestValidate_LogFile_SkippedWhenOff(t *testing.T) {
+	c := &Config{Transport: "stdio", LogLevel: "off"}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// When log level is off, LogFile doesn't need to be set.
+}
+
 func TestIsRegex(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"fmt"
+	"net/http"
 	"sync"
 
 	"k8s.io/client-go/discovery"
@@ -16,10 +17,11 @@ import (
 
 // ClientPool manages lazily-created Kubernetes clients for multiple contexts.
 type ClientPool struct {
-	cfg       *config.Config
-	rawConfig clientcmdapi.Config
-	mu        sync.RWMutex
-	clients   map[string]*ContextClient
+	cfg              *config.Config
+	rawConfig        clientcmdapi.Config
+	mu               sync.RWMutex
+	clients          map[string]*ContextClient
+	transportWrapper func(http.RoundTripper) http.RoundTripper
 }
 
 // ContextClient bundles the clients needed for a single kube-context.
@@ -45,6 +47,13 @@ func NewClientPool(cfg *config.Config) (*ClientPool, error) {
 		rawConfig: *apiConfig,
 		clients:   make(map[string]*ContextClient),
 	}, nil
+}
+
+// SetTransportWrapper sets an HTTP transport wrapper that will be applied to
+// all Kubernetes REST clients created by this pool. Must be called before
+// any ClientFor calls.
+func (p *ClientPool) SetTransportWrapper(wrapper func(http.RoundTripper) http.RoundTripper) {
+	p.transportWrapper = wrapper
 }
 
 // Contexts returns the list of allowed context names.
@@ -134,6 +143,9 @@ func (p *ClientPool) restConfigFor(contextName string) (*rest.Config, error) {
 	restCfg, err := cc.ClientConfig()
 	if err != nil {
 		return nil, fmt.Errorf("building rest config for context %q: %w", contextName, err)
+	}
+	if p.transportWrapper != nil {
+		restCfg.WrapTransport = p.transportWrapper
 	}
 	return restCfg, nil
 }

--- a/internal/kube/client_test.go
+++ b/internal/kube/client_test.go
@@ -1,6 +1,7 @@
 package kube
 
 import (
+	"net/http"
 	"sort"
 	"testing"
 
@@ -238,5 +239,42 @@ func TestResolveContext_EmptyDefaultNotInKubeconfig(t *testing.T) {
 	_, err := pool.ResolveContext("")
 	if err == nil {
 		t.Fatal("ResolveContext('') expected error when default context not in kubeconfig")
+	}
+}
+
+// --------------- TransportWrapper ---------------
+
+func TestNewClientPool_WithTransportWrapper(t *testing.T) {
+	called := false
+	wrapper := func(rt http.RoundTripper) http.RoundTripper {
+		called = true
+		return rt
+	}
+
+	pool := newTestPool(
+		&config.Config{AllowedContexts: []string{"*"}},
+		"ctx-a", "ctx-a",
+	)
+	pool.transportWrapper = wrapper
+
+	if pool.transportWrapper == nil {
+		t.Fatal("expected transportWrapper to be set")
+	}
+
+	// Call the wrapper to verify it's the one we set.
+	pool.transportWrapper(http.DefaultTransport)
+	if !called {
+		t.Fatal("expected transportWrapper to be called")
+	}
+}
+
+func TestNewClientPool_WithoutTransportWrapper(t *testing.T) {
+	pool := newTestPool(
+		&config.Config{AllowedContexts: []string{"*"}},
+		"ctx-a", "ctx-a",
+	)
+
+	if pool.transportWrapper != nil {
+		t.Fatal("expected transportWrapper to be nil by default")
 	}
 }

--- a/internal/mcplog/level.go
+++ b/internal/mcplog/level.go
@@ -39,11 +39,14 @@ func ParseLogLevel(s string) (LogLevel, error) {
 	}
 }
 
-// DefaultLogPath returns the default log file path: ~/.kubectl-mcp/server.log.
+// DefaultLogPath returns the default log file path:
+// ~/.kubectl-mcp/server-<pid>.log. The PID suffix ensures multiple
+// concurrent server instances do not conflict on the same file.
 func DefaultLogPath() string {
+	name := fmt.Sprintf("server-%d.log", os.Getpid())
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return filepath.Join(os.TempDir(), "kubectl-mcp", "server.log")
+		return filepath.Join(os.TempDir(), "kubectl-mcp", name)
 	}
-	return filepath.Join(home, ".kubectl-mcp", "server.log")
+	return filepath.Join(home, ".kubectl-mcp", name)
 }

--- a/internal/mcplog/level.go
+++ b/internal/mcplog/level.go
@@ -2,6 +2,8 @@ package mcplog
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -35,4 +37,13 @@ func ParseLogLevel(s string) (LogLevel, error) {
 	default:
 		return "", fmt.Errorf("invalid log level %q: must be off, info, or debug", s)
 	}
+}
+
+// DefaultLogPath returns the default log file path: ~/.kubectl-mcp/server.log.
+func DefaultLogPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), "kubectl-mcp", "server.log")
+	}
+	return filepath.Join(home, ".kubectl-mcp", "server.log")
 }

--- a/internal/mcplog/level.go
+++ b/internal/mcplog/level.go
@@ -1,0 +1,38 @@
+package mcplog
+
+import (
+	"fmt"
+	"strings"
+)
+
+// LogLevel controls the verbosity of server-side logging.
+type LogLevel string
+
+const (
+	// LogLevelOff disables all logging (stderr and MCP notifications).
+	LogLevelOff LogLevel = "off"
+	// LogLevelInfo logs tool call summaries and errors (default).
+	LogLevelInfo LogLevel = "info"
+	// LogLevelDebug logs full arguments, results, and K8s HTTP details.
+	LogLevelDebug LogLevel = "debug"
+)
+
+// String returns the log level as a lowercase string.
+func (l LogLevel) String() string {
+	return string(l)
+}
+
+// ParseLogLevel parses a string into a LogLevel.
+// Accepted values (case-insensitive): "off", "info", "debug".
+func ParseLogLevel(s string) (LogLevel, error) {
+	switch strings.ToLower(s) {
+	case "off":
+		return LogLevelOff, nil
+	case "info":
+		return LogLevelInfo, nil
+	case "debug":
+		return LogLevelDebug, nil
+	default:
+		return "", fmt.Errorf("invalid log level %q: must be off, info, or debug", s)
+	}
+}

--- a/internal/mcplog/level_test.go
+++ b/internal/mcplog/level_test.go
@@ -1,6 +1,9 @@
 package mcplog
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -56,5 +59,29 @@ func TestLogLevel_String(t *testing.T) {
 				t.Fatalf("LogLevel.String() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDefaultLogPath(t *testing.T) {
+	got := DefaultLogPath()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home dir")
+	}
+
+	want := filepath.Join(home, ".kubectl-mcp", "server.log")
+	if got != want {
+		t.Fatalf("DefaultLogPath() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultLogPath_ContainsDotKubectlMcp(t *testing.T) {
+	got := DefaultLogPath()
+	if !strings.Contains(got, ".kubectl-mcp") {
+		t.Fatalf("DefaultLogPath() = %q, expected to contain .kubectl-mcp", got)
+	}
+	if !strings.HasSuffix(got, "server.log") {
+		t.Fatalf("DefaultLogPath() = %q, expected to end with server.log", got)
 	}
 }

--- a/internal/mcplog/level_test.go
+++ b/internal/mcplog/level_test.go
@@ -1,6 +1,7 @@
 package mcplog
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -70,9 +71,17 @@ func TestDefaultLogPath(t *testing.T) {
 		t.Skip("cannot determine home dir")
 	}
 
-	want := filepath.Join(home, ".kubectl-mcp", "server.log")
+	want := filepath.Join(home, ".kubectl-mcp", fmt.Sprintf("server-%d.log", os.Getpid()))
 	if got != want {
 		t.Fatalf("DefaultLogPath() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultLogPath_ContainsPID(t *testing.T) {
+	got := DefaultLogPath()
+	pid := fmt.Sprintf("%d", os.Getpid())
+	if !strings.Contains(got, pid) {
+		t.Fatalf("DefaultLogPath() = %q, expected to contain PID %s", got, pid)
 	}
 }
 
@@ -81,7 +90,7 @@ func TestDefaultLogPath_ContainsDotKubectlMcp(t *testing.T) {
 	if !strings.Contains(got, ".kubectl-mcp") {
 		t.Fatalf("DefaultLogPath() = %q, expected to contain .kubectl-mcp", got)
 	}
-	if !strings.HasSuffix(got, "server.log") {
-		t.Fatalf("DefaultLogPath() = %q, expected to end with server.log", got)
+	if !strings.HasSuffix(got, ".log") {
+		t.Fatalf("DefaultLogPath() = %q, expected to end with .log", got)
 	}
 }

--- a/internal/mcplog/level_test.go
+++ b/internal/mcplog/level_test.go
@@ -1,0 +1,60 @@
+package mcplog
+
+import (
+	"testing"
+)
+
+func TestParseLogLevel_Valid(t *testing.T) {
+	tests := []struct {
+		input string
+		want  LogLevel
+	}{
+		{"off", LogLevelOff},
+		{"info", LogLevelInfo},
+		{"debug", LogLevelDebug},
+		{"OFF", LogLevelOff},
+		{"Info", LogLevelInfo},
+		{"DEBUG", LogLevelDebug},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseLogLevel(tt.input)
+			if err != nil {
+				t.Fatalf("ParseLogLevel(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseLogLevel(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseLogLevel_Invalid(t *testing.T) {
+	invalids := []string{"", "trace", "warn", "verbose", "1", " info"}
+	for _, input := range invalids {
+		t.Run(input, func(t *testing.T) {
+			_, err := ParseLogLevel(input)
+			if err == nil {
+				t.Fatalf("ParseLogLevel(%q) expected error, got nil", input)
+			}
+		})
+	}
+}
+
+func TestLogLevel_String(t *testing.T) {
+	tests := []struct {
+		level LogLevel
+		want  string
+	}{
+		{LogLevelOff, "off"},
+		{LogLevelInfo, "info"},
+		{LogLevelDebug, "debug"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.level), func(t *testing.T) {
+			if got := tt.level.String(); got != tt.want {
+				t.Fatalf("LogLevel.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/mcplog/transport.go
+++ b/internal/mcplog/transport.go
@@ -1,0 +1,59 @@
+package mcplog
+
+import (
+	"log"
+	"net/http"
+	"regexp"
+	"time"
+)
+
+// discoveryPrefixes lists K8s API discovery path patterns to skip.
+// /api, /apis — root discovery
+// /api/v1     — core version discovery (but NOT /api/v1/pods which is a resource)
+// /apis/X/v1  — group version discovery (but NOT /apis/apps/v1/deployments)
+var coreDiscovery = regexp.MustCompile(`^/api(/[^/]+)?$`)
+var groupDiscovery = regexp.MustCompile(`^/apis(/[^/]+(/[^/]+)?)?$`)
+
+// LoggingTransport wraps an http.RoundTripper and logs each HTTP
+// request/response to the provided logger. Discovery-only paths are
+// filtered out to reduce noise.
+type LoggingTransport struct {
+	inner  http.RoundTripper
+	logger *log.Logger
+}
+
+// NewLoggingTransport creates a new LoggingTransport that delegates to inner
+// and logs HTTP details to logger.
+func NewLoggingTransport(inner http.RoundTripper, logger *log.Logger) *LoggingTransport {
+	return &LoggingTransport{inner: inner, logger: logger}
+}
+
+// RoundTrip executes the request via the inner transport and logs the result.
+func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if isDiscoveryPath(req.URL.Path) {
+		return t.inner.RoundTrip(req)
+	}
+
+	start := time.Now()
+	resp, err := t.inner.RoundTrip(req)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.logger.Printf("  K8s: %s %s → error: %v (%s)", req.Method, req.URL.Path, err, elapsed.Round(time.Millisecond))
+		return nil, err
+	}
+
+	size := resp.Header.Get("Content-Length")
+	if size == "" {
+		size = "?"
+	}
+	t.logger.Printf("  K8s: %s %s → %d (%sB, %s)",
+		req.Method, req.URL.Path, resp.StatusCode,
+		size, elapsed.Round(time.Millisecond))
+
+	return resp, nil
+}
+
+func isDiscoveryPath(path string) bool {
+	return coreDiscovery.MatchString(path) || groupDiscovery.MatchString(path)
+}

--- a/internal/mcplog/transport_test.go
+++ b/internal/mcplog/transport_test.go
@@ -1,0 +1,176 @@
+package mcplog
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestLoggingTransport_LogsRequestAndResponse(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+
+	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"kind":"Pod"}`)),
+			Header:     http.Header{"Content-Length": []string{"14"}},
+		}, nil
+	})
+
+	transport := NewLoggingTransport(inner, logger)
+
+	req, _ := http.NewRequest("GET", "https://k8s.example.com/api/v1/namespaces/default/pods/nginx", nil)
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "GET") {
+		t.Errorf("expected log to contain HTTP method GET, got: %s", output)
+	}
+	if !strings.Contains(output, "/api/v1/namespaces/default/pods/nginx") {
+		t.Errorf("expected log to contain URL path, got: %s", output)
+	}
+	if !strings.Contains(output, "200") {
+		t.Errorf("expected log to contain status code 200, got: %s", output)
+	}
+}
+
+func TestLoggingTransport_FiltersDiscoveryPaths(t *testing.T) {
+	discoveryPaths := []string{
+		"https://k8s.example.com/api",
+		"https://k8s.example.com/api?timeout=10s",
+		"https://k8s.example.com/apis",
+		"https://k8s.example.com/apis?timeout=10s",
+		"https://k8s.example.com/api/v1",
+		"https://k8s.example.com/apis/apps/v1",
+	}
+
+	for _, urlStr := range discoveryPaths {
+		t.Run(urlStr, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := log.New(&buf, "", 0)
+
+			inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			})
+
+			transport := NewLoggingTransport(inner, logger)
+			req, _ := http.NewRequest("GET", urlStr, nil)
+			resp, err := transport.RoundTrip(req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			_ = resp.Body.Close()
+
+			if buf.Len() > 0 {
+				t.Errorf("expected no log output for discovery path %s, got: %s", urlStr, buf.String())
+			}
+		})
+	}
+}
+
+func TestLoggingTransport_LogsNonDiscoveryPaths(t *testing.T) {
+	nonDiscoveryPaths := []string{
+		"https://k8s.example.com/api/v1/namespaces",
+		"https://k8s.example.com/api/v1/pods",
+		"https://k8s.example.com/apis/apps/v1/deployments",
+		"https://k8s.example.com/apis/apps/v1/namespaces/default/deployments/nginx",
+	}
+
+	for _, urlStr := range nonDiscoveryPaths {
+		t.Run(urlStr, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := log.New(&buf, "", 0)
+
+			inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{}`)),
+					Header:     http.Header{"Content-Length": []string{"2"}},
+				}, nil
+			})
+
+			transport := NewLoggingTransport(inner, logger)
+			req, _ := http.NewRequest("GET", urlStr, nil)
+			resp, err := transport.RoundTrip(req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			_ = resp.Body.Close()
+
+			if buf.Len() == 0 {
+				t.Errorf("expected log output for non-discovery path %s", urlStr)
+			}
+		})
+	}
+}
+
+func TestLoggingTransport_HandlesTransportError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+
+	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, io.ErrUnexpectedEOF
+	})
+
+	transport := NewLoggingTransport(inner, logger)
+	req, _ := http.NewRequest("GET", "https://k8s.example.com/api/v1/namespaces/default/pods", nil)
+	_, err := transport.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "error") || !strings.Contains(output, "GET") {
+		t.Errorf("expected log to contain error info, got: %s", output)
+	}
+}
+
+func TestLoggingTransport_DelegatesUnmodified(t *testing.T) {
+	expectedBody := `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"nginx"}}`
+	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(expectedBody)),
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+	transport := NewLoggingTransport(inner, logger)
+
+	req, _ := http.NewRequest("GET", "https://k8s.example.com/api/v1/namespaces/default/pods/nginx", nil)
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if string(body) != expectedBody {
+		t.Fatalf("response body modified: got %q, want %q", string(body), expectedBody)
+	}
+}
+
+// roundTripFunc adapts a function to http.RoundTripper.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}


### PR DESCRIPTION
## Summary

Adds `--log-level` and `--log-file` CLI flags for configurable, file-based logging.

## Log Levels

| Level   | Log file output                     | MCP client notifications         |
|---------|-------------------------------------|----------------------------------|
| `off`   | None                                | None                             |
| `info`  | Tool call summaries + success/fail  | Errors & warnings only           |
| `debug` | Full args, results, K8s HTTP calls  | Everything at debug level        |

Default: **`info`** (preserves current behaviour).

## File-Based Logging

All log output goes to a file instead of stderr (which is unreliable with stdio transport). Default path: `~/.kubectl-mcp/server-<pid>.log`. The PID in the filename prevents conflicts when multiple MCP instances run concurrently. Override with `--log-file <path>`.

At **`debug`** level, a logging HTTP RoundTripper wraps the K8s REST transport to log every request/response (method, URL, status, size, duration). Discovery paths (`/api`, `/apis`) are filtered to reduce noise.

Also configurable via environment variables: `KUBECTL_MCP_LOG_LEVEL`, `KUBECTL_MCP_LOG_FILE`.

## Changes

- `internal/mcplog/level.go` — LogLevel type, parser, DefaultLogPath (PID-based)
- `internal/mcplog/transport.go` — K8s HTTP logging transport
- `internal/config/config.go` — LogLevel + LogFile fields, validation
- `internal/cmd/root.go` — `--log-level` and `--log-file` flags
- `internal/cmd/serve.go` — File-based logger, level-aware hooks, transport wiring
- `internal/kube/client.go` — Transport wrapper support in ClientPool
- `e2e/log_level_test.go` — E2E tests for all levels
- Full TDD with unit tests for every component