### PR TITLE
fix: prevent close-of-closed-channel panic in port-forward session cleanup

### DIFF
--- a/internal/tools/portforward.go
+++ b/internal/tools/portforward.go
@@ -47,6 +47,18 @@ type PortForwarder interface {
 // activeForwards tracks live port-forward sessions for cleanup.
 var activeForwards sync.Map
 
+// portForwardSession wraps the stop channel with a sync.Once so concurrent
+// callers (timeout goroutine and stop_port_forward) can both safely call stop
+// without risking a "close of closed channel" panic.
+type portForwardSession struct {
+	stopCh chan struct{}
+	once   sync.Once
+}
+
+func (s *portForwardSession) stop() {
+	s.once.Do(func() { close(s.stopCh) })
+}
+
 // portForwardResponse is the JSON response returned to the caller.
 type portForwardResponse struct {
 	Pod        string  `json:"pod"`
@@ -356,16 +368,17 @@ Examples: "my-pod", "pod/my-pod", "svc/my-service", "deploy/my-app", "sts/my-set
 
 		// Store for cleanup and schedule timeout.
 		key := fmt.Sprintf("%s/%s/%d", namespace, podName, result.LocalPort)
-		activeForwards.Store(key, result.StopCh)
+		session := &portForwardSession{stopCh: result.StopCh}
+		activeForwards.Store(key, session)
 
 		go func() {
 			timer := time.NewTimer(timeout)
 			defer timer.Stop()
 			select {
 			case <-timer.C:
-				close(result.StopCh)
+				session.stop()
 				activeForwards.Delete(key)
-			case <-result.StopCh:
+			case <-session.stopCh:
 				activeForwards.Delete(key)
 			}
 		}()

--- a/internal/tools/portforward_stop.go
+++ b/internal/tools/portforward_stop.go
@@ -64,8 +64,8 @@ func stopForwardSession(sessionID string) (*mcp.CallToolResult, error) {
 		return mcp.NewToolResultError(fmt.Sprintf("no active port-forward session with key %q", sessionID)), nil
 	}
 
-	if stopCh, ok := val.(chan struct{}); ok {
-		close(stopCh)
+	if session, ok := val.(*portForwardSession); ok {
+		session.stop()
 	}
 
 	return mcp.NewToolResultText(fmt.Sprintf("Stopped port-forward session %q", sessionID)), nil

--- a/internal/tools/portforward_stop_test.go
+++ b/internal/tools/portforward_stop_test.go
@@ -37,8 +37,8 @@ func TestStopPortForward_ListActive(t *testing.T) {
 		return true
 	})
 
-	ch1 := make(chan struct{})
-	ch2 := make(chan struct{})
+	ch1 := &portForwardSession{stopCh: make(chan struct{})}
+	ch2 := &portForwardSession{stopCh: make(chan struct{})}
 	activeForwards.Store("default/pod-a/8080", ch1)
 	activeForwards.Store("default/pod-b/9090", ch2)
 
@@ -72,8 +72,8 @@ func TestStopPortForward_StopSession(t *testing.T) {
 		return true
 	})
 
-	ch := make(chan struct{})
-	activeForwards.Store("default/my-pod/8080", ch)
+	session := &portForwardSession{stopCh: make(chan struct{})}
+	activeForwards.Store("default/my-pod/8080", session)
 
 	handler := getHandler(t, "stop_port_forward", func(s *server.MCPServer) {
 		registerStopPortForward(s)
@@ -93,7 +93,7 @@ func TestStopPortForward_StopSession(t *testing.T) {
 
 	// Verify channel was closed.
 	select {
-	case <-ch:
+	case <-session.stopCh:
 		// OK, channel is closed.
 	default:
 		t.Error("expected stop channel to be closed")
@@ -102,6 +102,33 @@ func TestStopPortForward_StopSession(t *testing.T) {
 	// Verify it was removed from the map.
 	if _, loaded := activeForwards.Load("default/my-pod/8080"); loaded {
 		t.Error("expected session to be removed from activeForwards")
+	}
+}
+
+func TestStopPortForward_ConcurrentStopNoPanic(t *testing.T) {
+	// Verify that calling stop from multiple goroutines simultaneously never panics.
+	// This is the race that sync.Once in portForwardSession prevents.
+	session := &portForwardSession{stopCh: make(chan struct{})}
+	activeForwards.Store("default/race-pod/8080", session)
+	t.Cleanup(func() { activeForwards.Delete("default/race-pod/8080") })
+
+	const goroutines = 50
+	done := make(chan struct{}, goroutines)
+	for range goroutines {
+		go func() {
+			session.stop()
+			done <- struct{}{}
+		}()
+	}
+	for range goroutines {
+		<-done
+	}
+
+	select {
+	case <-session.stopCh:
+		// OK
+	default:
+		t.Error("expected stop channel to be closed after concurrent stops")
 	}
 }
 


### PR DESCRIPTION
## Summary

- The timeout goroutine and `stop_port_forward` could concurrently close the same `StopCh`, causing a `close of closed channel` panic
- Introduced `portForwardSession` wrapping the stop channel with `sync.Once` — both callers now call `session.stop()` which is safe to call any number of times
- `activeForwards` now stores `*portForwardSession` instead of the raw channel
- Added `TestStopPortForward_ConcurrentStopNoPanic` which fires 50 goroutines simultaneously calling `stop()` to verify no panic under the race detector

## Test plan

- [ ] `go test ./internal/tools/... -run TestStopPortForward -race -count=3` passes
- [ ] `go build ./...` passes
- [ ] CI workflows green