### PR TITLE
fix: validate port numbers before uint16 cast in port_forward

### DIFF
--- a/e2e/port_forward_test.go
+++ b/e2e/port_forward_test.go
@@ -27,7 +27,7 @@ func TestPortForward(t *testing.T) {
 					t.Error("expected error for remotePort=0")
 				}
 				text := resultText(result)
-				if !strings.Contains(text, "remotePort must be a valid port number") {
+				if !strings.Contains(text, "remotePort must be between 1 and 65535") {
 					t.Errorf("expected port validation error, got: %s", text)
 				}
 			})

--- a/internal/tools/portforward.go
+++ b/internal/tools/portforward.go
@@ -312,13 +312,20 @@ Examples: "my-pod", "pod/my-pod", "svc/my-service", "deploy/my-app", "sts/my-set
 
 		namespace, _ := req.RequireString("namespace")
 		resourceStr, _ := req.RequireString("resource")
-		remotePort := uint16(req.GetFloat("remotePort", 0))
-		localPort := uint16(req.GetFloat("localPort", 0))
-		timeout := clampTimeout(req.GetFloat("timeout", defaultPortForwardTimeout.Seconds()))
 
-		if remotePort == 0 {
-			return mcp.NewToolResultError("remotePort must be a valid port number (1-65535)"), nil
+		remotePortF := req.GetFloat("remotePort", 0)
+		if remotePortF < 1 || remotePortF > 65535 {
+			return mcp.NewToolResultError("remotePort must be between 1 and 65535"), nil
 		}
+		remotePort := uint16(remotePortF)
+
+		localPortF := req.GetFloat("localPort", 0)
+		if localPortF < 0 || localPortF > 65535 {
+			return mcp.NewToolResultError("localPort must be between 0 and 65535"), nil
+		}
+		localPort := uint16(localPortF)
+
+		timeout := clampTimeout(req.GetFloat("timeout", defaultPortForwardTimeout.Seconds()))
 
 		kind, name := parseResource(resourceStr)
 

--- a/internal/tools/portforward_test.go
+++ b/internal/tools/portforward_test.go
@@ -251,6 +251,54 @@ func TestPortForward_InvalidPort(t *testing.T) {
 	}
 }
 
+func TestPortForward_PortValidation(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.AllowWrite = true
+	fakeCS := fake.NewClientset()
+	dynClient := newWriteFakeDynClient(testPod("my-pod", "default"))
+	pool := buildWritePool(cfg, dynClient, fakeCS)
+	fwd := &fakePortForwarder{}
+
+	handler := getHandler(t, "port_forward", func(s *server.MCPServer) {
+		registerPortForward(s, pool, fwd, cfg)
+	})
+
+	cases := []struct {
+		name       string
+		remotePort float64
+		localPort  float64
+		wantErrSub string
+	}{
+		{"remotePort zero", 0, 0, "remotePort"},
+		{"remotePort negative", -1, 0, "remotePort"},
+		{"remotePort overflow 70000", 70000, 0, "remotePort"},
+		{"remotePort 65536", 65536, 0, "remotePort"},
+		{"localPort negative", 8080, -1, "localPort"},
+		{"localPort overflow 70000", 8080, 70000, "localPort"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := handler(context.Background(), callToolReq(map[string]any{
+				"namespace":  "default",
+				"resource":   "my-pod",
+				"remotePort": tc.remotePort,
+				"localPort":  tc.localPort,
+			}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !res.IsError {
+				t.Errorf("expected error for %s", tc.name)
+			}
+			text := resultText(t, res)
+			if !strings.Contains(text, tc.wantErrSub) {
+				t.Errorf("expected %q in error, got: %s", tc.wantErrSub, text)
+			}
+		})
+	}
+}
+
 // --- resource parameter tests ---
 
 func TestParseResource(t *testing.T) {


### PR DESCRIPTION
## Summary

- `GetFloat` returns `float64`; casting directly to `uint16` silently overflows (e.g. 70000 → 4464), bypassing the zero-check that follows
- Now validates `remotePort` is 1–65535 and `localPort` is 0–65535 before casting, returning an explicit error for out-of-range values
- Added `TestPortForward_PortValidation` covering zero, negative, and overflow values for both ports

## Test plan

- [ ] `go test ./internal/tools/... -run TestPortForward -count=1` passes
- [ ] All 6 new sub-test cases pass (remotePort zero/negative/70000/65536, localPort negative/70000)
- [ ] CI workflows green