### PR TITLE
fix: reject relative and path-traversal dest_path in copy_to_pod

### DIFF
--- a/internal/tools/cp_to_pod.go
+++ b/internal/tools/cp_to_pod.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"path"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -118,6 +119,12 @@ func registerCopyToPod(s *server.MCPServer, pool *kube.ClientPool, runner CopyRu
 		destPath, err := req.RequireString("dest_path")
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
+		}
+		if !path.IsAbs(destPath) {
+			return mcp.NewToolResultError("dest_path must be an absolute path (start with /)"), nil
+		}
+		if strings.Contains(destPath, "..") {
+			return mcp.NewToolResultError("dest_path must not contain '..'"), nil
 		}
 		content, err := req.RequireString("content")
 		if err != nil {

--- a/internal/tools/cp_to_pod_test.go
+++ b/internal/tools/cp_to_pod_test.go
@@ -414,3 +414,47 @@ func TestCopyToPod_WithContainer(t *testing.T) {
 		t.Errorf("expected container=sidecar, got: %q", capturedContainer)
 	}
 }
+
+func TestCopyToPod_PathValidation(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.AllowWrite = true
+	pool := buildWritePool(cfg, newWriteFakeDynClient(), fake.NewClientset())
+
+	runner := &fakeCopyRunner{}
+	handler := getHandler(t, "copy_to_pod", func(s *server.MCPServer) {
+		registerCopyToPod(s, pool, runner, cfg)
+	})
+
+	cases := []struct {
+		name       string
+		destPath   string
+		wantErrSub string
+	}{
+		{"relative path", "etc/passwd", "absolute"},
+		{"relative traversal", "../etc/passwd", "absolute"},
+		{"dot dot absolute", "/etc/../passwd", ".."},
+		{"dot dot only", "/..", ".."},
+		{"double dot in middle", "/var/../../../etc/passwd", ".."},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := handler(context.Background(), callToolReq(map[string]any{
+				"namespace": "default",
+				"pod":       "my-pod",
+				"dest_path": tc.destPath,
+				"content":   "data",
+			}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !res.IsError {
+				t.Errorf("expected error for dest_path=%q", tc.destPath)
+			}
+			text := resultText(t, res)
+			if !strings.Contains(text, tc.wantErrSub) {
+				t.Errorf("expected %q in error for dest_path=%q, got: %s", tc.wantErrSub, tc.destPath, text)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `dest_path` was passed to `buildTarBuffer` without validation; a relative path like `../etc/passwd` could extract to an unintended location inside the pod
- Now validates that `dest_path` is absolute (starts with `/`) and contains no `..` segments
- Added `TestCopyToPod_PathValidation` with 5 sub-cases covering relative paths, traversal attempts, and mixed absolute+dot-dot inputs

## Test plan

- [ ] `go test ./internal/tools/... -run TestCopyToPod` passes
- [ ] All 5 new path validation sub-tests pass
- [ ] CI workflows green