### PR TITLE
fix: reject content_type with newlines in api_raw to prevent header injection

### DIFF
--- a/internal/tools/raw.go
+++ b/internal/tools/raw.go
@@ -94,6 +94,11 @@ func registerRawAPI(s *server.MCPServer, pool *kube.ClientPool, cfg *config.Conf
 		body := req.GetString("body", "")
 		contentType := req.GetString("content_type", "application/json")
 
+		// Validate content_type: newlines would allow HTTP header injection.
+		if strings.ContainsAny(contentType, "\r\n") {
+			return mcp.NewToolResultError("content_type must not contain newline characters"), nil
+		}
+
 		// Validate path.
 		if path == "" {
 			return mcp.NewToolResultError("path is required"), nil

--- a/internal/tools/raw_test.go
+++ b/internal/tools/raw_test.go
@@ -239,6 +239,41 @@ func TestRawAPI_MethodCaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestRawAPI_ContentTypeValidation(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.AllowRaw = true
+	requester := &fakeRawRequester{response: []byte("ok"), status: 200}
+	handler := rawHandler(t, cfg, requester)
+
+	cases := []struct {
+		name        string
+		contentType string
+	}{
+		{"CR only", "application/json\r"},
+		{"LF only", "application/json\n"},
+		{"CRLF injection", "application/json\r\nX-Evil: injected"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := handler(context.Background(), callToolReq(map[string]any{
+				"path":         "/api/v1/pods",
+				"content_type": tc.contentType,
+			}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !res.IsError {
+				t.Errorf("expected error for content_type=%q", tc.contentType)
+			}
+			text := resultText(t, res)
+			if !strings.Contains(text, "newline") {
+				t.Errorf("expected newline error message, got: %s", text)
+			}
+		})
+	}
+}
+
 func TestRawAPI_NotRegisteredWithoutAllowRaw(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.AllowRaw = false


### PR DESCRIPTION
## Summary

- `content_type` was forwarded to the Kubernetes REST client without validation; a value containing `\r\n` could inject arbitrary HTTP headers
- Added an upfront check rejecting any `content_type` containing CR or LF, returning a clear error message
- Added `TestRawAPI_ContentTypeValidation` covering CR-only, LF-only, and full CRLF injection cases

## Test plan

- [ ] `go test ./internal/tools/... -run TestRawAPI` passes
- [ ] All 3 new content-type sub-tests pass
- [ ] CI workflows green