### PR TITLE
fix: apply resolveFieldValidation in create_resource to match apply_resource

### DIFF
--- a/internal/tools/create.go
+++ b/internal/tools/create.go
@@ -61,7 +61,10 @@ func registerCreateResource(s *server.MCPServer, pool *kube.ClientPool, cfg *con
 		}
 
 		dryRun := dryRunOption(req.GetBool("dryRun", false))
-		validate := req.GetString("validate", "Strict")
+		fieldValidation, err := resolveFieldValidation(req.GetString("validate", "strict"))
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
 
 		if len(dryRun) == 0 {
 			if err := applySafetyDelay(ctx, req, cfg.SafetyDelayWrite); err != nil {
@@ -90,7 +93,7 @@ func registerCreateResource(s *server.MCPServer, pool *kube.ClientPool, cfg *con
 
 			result, err := res.Create(ctx, obj, metav1.CreateOptions{
 				DryRun:          dryRun,
-				FieldValidation: validate,
+				FieldValidation: fieldValidation,
 			})
 			if err != nil {
 				if errors.IsAlreadyExists(err) {

--- a/internal/tools/create_test.go
+++ b/internal/tools/create_test.go
@@ -355,6 +355,35 @@ func TestCreateResource_MissingManifest(t *testing.T) {
 	}
 }
 
+func TestCreateResource_InvalidValidate(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.AllowWrite = true
+
+	fakeCS := fake.NewClientset()
+	dynClient := newWriteFakeDynClient()
+
+	pool := buildWritePool(cfg, dynClient, fakeCS)
+	handler := getHandler(t, "create_resource", func(s *server.MCPServer) {
+		registerCreateResource(s, pool, cfg)
+	})
+
+	manifest := `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm","namespace":"default"}}`
+	res, err := handler(context.Background(), callToolReq(map[string]any{
+		"manifest": manifest,
+		"validate": "invalid-value",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatal("expected error for invalid validate value")
+	}
+	text := resultText(t, res)
+	if !strings.Contains(text, "validate") {
+		t.Errorf("expected error to mention 'validate', got: %s", text)
+	}
+}
+
 // --- parseManifests unit tests ---
 
 func TestParseManifests_SingleDoc(t *testing.T) {


### PR DESCRIPTION
## Summary
- `create_resource` was passing the raw `validate` string directly to `metav1.CreateOptions.FieldValidation`, bypassing the normalization and input validation that `apply_resource` already performs via `resolveFieldValidation`
- Invalid values like `"Strict"` (capital S) or `"garbage"` were silently forwarded to the Kubernetes API
- Aligned `create_resource` with `apply_resource`: calls `resolveFieldValidation` and returns a clear error for unrecognised values

## Test plan
- [ ] `TestCreateResource_InvalidValidate` — verifies that an invalid validate value returns an error mentioning "validate"
- [ ] All existing `TestCreateResource_*` tests pass unmodified (dry-run, conflict, multi-doc, etc.)
- [ ] `go test ./internal/tools/... -race -count=1`