### PR TITLE
fix: propagate tar write errors in buildTarBuffer instead of silently discarding

### DIFF
--- a/internal/tools/cp_to_pod.go
+++ b/internal/tools/cp_to_pod.go
@@ -142,7 +142,10 @@ func registerCopyToPod(s *server.MCPServer, pool *kube.ClientPool, runner CopyRu
 			return mcp.NewToolResultError(fmt.Sprintf("safety delay interrupted: %v", err)), nil
 		}
 
-		tarBuf := buildTarBuffer(destPath, data)
+		tarBuf, err := buildTarBuffer(destPath, data)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to build tar archive: %v", err)), nil
+		}
 
 		var stdout, stderr bytes.Buffer
 		if err := runner.Run(ctx, cc.Clientset, cc.RestConfig, namespace, pod, container,
@@ -172,17 +175,23 @@ func decodeContent(content, encoding string) ([]byte, error) {
 
 // buildTarBuffer creates an in-memory tar archive with a single file at destPath.
 // The leading slash is stripped so tar extracts correctly under -C /.
-func buildTarBuffer(destPath string, data []byte) io.Reader {
+func buildTarBuffer(destPath string, data []byte) (io.Reader, error) {
 	name := strings.TrimPrefix(destPath, "/")
 
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
-	_ = tw.WriteHeader(&tar.Header{
+	if err := tw.WriteHeader(&tar.Header{
 		Name: name,
 		Mode: 0644,
 		Size: int64(len(data)),
-	})
-	_, _ = tw.Write(data)
-	_ = tw.Close()
-	return &buf
+	}); err != nil {
+		return nil, err
+	}
+	if _, err := tw.Write(data); err != nil {
+		return nil, err
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	return &buf, nil
 }

--- a/internal/tools/cp_to_pod_test.go
+++ b/internal/tools/cp_to_pod_test.go
@@ -458,3 +458,38 @@ func TestCopyToPod_PathValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildTarBuffer_Success(t *testing.T) {
+	reader, err := buildTarBuffer("/etc/config.yaml", []byte("key: value\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tr := tar.NewReader(reader)
+	hdr, err := tr.Next()
+	if err != nil {
+		t.Fatalf("could not read tar header: %v", err)
+	}
+	if hdr.Name != "etc/config.yaml" {
+		t.Errorf("expected name=etc/config.yaml, got: %q", hdr.Name)
+	}
+	content, _ := io.ReadAll(tr)
+	if string(content) != "key: value\n" {
+		t.Errorf("unexpected content: %q", string(content))
+	}
+}
+
+func TestBuildTarBuffer_EmptyData(t *testing.T) {
+	reader, err := buildTarBuffer("/empty", []byte{})
+	if err != nil {
+		t.Fatalf("unexpected error for empty data: %v", err)
+	}
+	tr := tar.NewReader(reader)
+	hdr, err := tr.Next()
+	if err != nil {
+		t.Fatalf("could not read tar header: %v", err)
+	}
+	if hdr.Size != 0 {
+		t.Errorf("expected size=0, got: %d", hdr.Size)
+	}
+}


### PR DESCRIPTION
## Summary
- `buildTarBuffer` was discarding all errors from `tw.WriteHeader`, `tw.Write`, and `tw.Close` with `_ =`
- A write failure would produce a corrupt or empty tar archive; the pod's `tar` binary would silently extract nothing, giving no indication of failure
- Changed `buildTarBuffer` to return `(io.Reader, error)` and propagate all write errors to the caller, which returns a clear `mcp.NewToolResultError`

## Test plan
- [ ] `TestBuildTarBuffer_Success` — verifies happy-path tar creation
- [ ] `TestBuildTarBuffer_EmptyData` — verifies empty-file tar works
- [ ] All existing `TestCopyToPod_*` tests continue to pass
- [ ] `go test ./internal/tools/... -race -count=1`