### PR TITLE
fix: enforce 100 MB limit on in-memory file transfers in copy operations

### DIFF
--- a/internal/tools/cp_from_pod.go
+++ b/internal/tools/cp_from_pod.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"strings"
 	"unicode/utf8"
 
@@ -92,15 +93,21 @@ func registerCopyFromPod(s *server.MCPServer, pool *kube.ClientPool, runner Exec
 }
 
 // extractTarFile reads the first file entry from a tar stream and returns its bytes.
+// Returns an error if the file exceeds maxCopyBytes.
 func extractTarFile(r *bytes.Buffer) ([]byte, error) {
 	tr := tar.NewReader(r)
 	_, err := tr.Next()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read tar header: %w", err)
 	}
+
+	limited := io.LimitReader(tr, int64(maxCopyBytes)+1)
 	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(tr); err != nil {
+	if _, err := buf.ReadFrom(limited); err != nil {
 		return nil, fmt.Errorf("failed to read tar content: %w", err)
+	}
+	if buf.Len() > maxCopyBytes {
+		return nil, fmt.Errorf("file exceeds maximum allowed size of %d MB", maxCopyBytes/(1024*1024))
 	}
 	return buf.Bytes(), nil
 }

--- a/internal/tools/cp_from_pod_test.go
+++ b/internal/tools/cp_from_pod_test.go
@@ -326,3 +326,59 @@ func TestCopyFromPod_WithContainer(t *testing.T) {
 		t.Errorf("expected container=sidecar, got: %q", capturedContainer)
 	}
 }
+
+func TestCopyFromPod_FileTooLarge(t *testing.T) {
+	// Build a tar with a file that exceeds maxCopyBytes.
+	var tarBuf bytes.Buffer
+	tw := tar.NewWriter(&tarBuf)
+	overLimit := int64(maxCopyBytes) + 1
+	_ = tw.WriteHeader(&tar.Header{
+		Name: "bigfile",
+		Mode: 0644,
+		Size: overLimit,
+	})
+	// Write just enough data to trigger the limit check.
+	_, _ = tw.Write(make([]byte, overLimit))
+	_ = tw.Close()
+
+	runner := &fakeTarExecRunner{tarContent: tarBuf.Bytes()}
+	cfg := defaultCfg()
+	pool := buildPool(cfg, defaultRawConfig(), newFakeDynClient(), fake.NewClientset())
+	handler := getHandler(t, "copy_from_pod", func(s *server.MCPServer) {
+		registerCopyFromPod(s, pool, runner, cfg)
+	})
+
+	res, err := handler(context.Background(), callToolReq(map[string]any{
+		"namespace": "default",
+		"pod":       "my-pod",
+		"src_path":  "/bigfile",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatal("expected error for oversized file")
+	}
+	text := resultText(t, res)
+	if !strings.Contains(text, "exceeds") {
+		t.Errorf("expected size limit error, got: %s", text)
+	}
+}
+
+func TestExtractTarFile_ExactLimit(t *testing.T) {
+	// A file exactly at the limit should succeed.
+	var tarBuf bytes.Buffer
+	tw := tar.NewWriter(&tarBuf)
+	data := make([]byte, maxCopyBytes)
+	_ = tw.WriteHeader(&tar.Header{Name: "file", Mode: 0644, Size: int64(len(data))})
+	_, _ = tw.Write(data)
+	_ = tw.Close()
+
+	got, err := extractTarFile(&tarBuf)
+	if err != nil {
+		t.Fatalf("unexpected error at exact limit: %v", err)
+	}
+	if len(got) != maxCopyBytes {
+		t.Errorf("expected %d bytes, got %d", maxCopyBytes, len(got))
+	}
+}

--- a/internal/tools/cp_to_pod.go
+++ b/internal/tools/cp_to_pod.go
@@ -137,6 +137,11 @@ func registerCopyToPod(s *server.MCPServer, pool *kube.ClientPool, runner CopyRu
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
+		if len(data) > maxCopyBytes {
+			return mcp.NewToolResultError(
+				fmt.Sprintf("content exceeds maximum allowed size of %d MB", maxCopyBytes/(1024*1024)),
+			), nil
+		}
 
 		if err := applySafetyDelay(ctx, req, cfg.SafetyDelayWrite); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("safety delay interrupted: %v", err)), nil

--- a/internal/tools/cp_to_pod_test.go
+++ b/internal/tools/cp_to_pod_test.go
@@ -493,3 +493,34 @@ func TestBuildTarBuffer_EmptyData(t *testing.T) {
 		t.Errorf("expected size=0, got: %d", hdr.Size)
 	}
 }
+
+func TestCopyToPod_ContentTooLarge(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.AllowWrite = true
+	pool := buildWritePool(cfg, newWriteFakeDynClient(), fake.NewClientset())
+
+	runner := &fakeCopyRunner{}
+	handler := getHandler(t, "copy_to_pod", func(s *server.MCPServer) {
+		registerCopyToPod(s, pool, runner, cfg)
+	})
+
+	// Send content that is one byte over the limit.
+	overLimit := make([]byte, maxCopyBytes+1)
+
+	res, err := handler(context.Background(), callToolReq(map[string]any{
+		"namespace": "default",
+		"pod":       "my-pod",
+		"dest_path": "/tmp/bigfile",
+		"content":   string(overLimit),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatal("expected error for oversized content")
+	}
+	text := resultText(t, res)
+	if !strings.Contains(text, "exceeds") {
+		t.Errorf("expected size limit error, got: %s", text)
+	}
+}

--- a/internal/tools/helpers.go
+++ b/internal/tools/helpers.go
@@ -11,6 +11,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// maxCopyBytes is the upper bound for in-memory file transfers in copy operations.
+const maxCopyBytes = 100 * 1024 * 1024 // 100 MB
+
 // requireStringOrJSON returns a string argument by key. If the LLM sends a
 // JSON object instead of a string, it marshals the object to a JSON string.
 // This handles the common case where a tool parameter is described as


### PR DESCRIPTION
## Summary
- `copy_from_pod` read entire files into a `bytes.Buffer` with no size cap — a large file from the pod could exhaust server memory
- `copy_to_pod` decoded the full `content` string into a `[]byte` before any size check — same risk from client-supplied content
- Added `maxCopyBytes = 100 MB` constant and enforced it in both tools

### Changes
- `helpers.go`: new `maxCopyBytes` constant (100 MB)
- `cp_from_pod.go`: `extractTarFile` now wraps the tar reader in `io.LimitReader(tr, maxCopyBytes+1)` and errors if the buffer exceeds the limit
- `cp_to_pod.go`: checks `len(data) > maxCopyBytes` after `decodeContent` and before the safety delay

## Test plan
- [ ] `TestCopyFromPod_FileTooLarge` — sends a 100MB+1 tar, expects a size-limit error
- [ ] `TestExtractTarFile_ExactLimit` — 100MB exactly is accepted
- [ ] `TestCopyToPod_ContentTooLarge` — sends content 1 byte over limit, expects error
- [ ] All existing `TestCopyFromPod_*` and `TestCopyToPod_*` tests continue to pass
- [ ] `go test ./internal/tools/... -race -count=1`