### PR TITLE
fix: recover from panics in tool and resource handlers

### DIFF
--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -64,6 +64,8 @@ var serveCmd = &cobra.Command{
 			server.WithPromptCapabilities(false),
 			server.WithLogging(),
 			server.WithElicitation(),
+			server.WithRecovery(),
+			server.WithResourceRecovery(),
 			server.WithHooks(hooks),
 		)
 


### PR DESCRIPTION
## Summary

The MCP server was built without panic recovery. mcp-go's stdio worker (`toolCallWorker` → `HandleMessage`) has no `recover()`, so an unrecovered panic in any tool/resource handler propagates up the worker goroutine and **terminates the whole process**, dropping all in-flight requests and requiring a restart.

This adds `server.WithRecovery()` and `server.WithResourceRecovery()` so handler panics become error results instead of crashing the server. This is defense-in-depth that contains the blast radius of any reachable panic source (e.g. malformed metrics quantities, unexpected unstructured shapes).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/cmd/`
- [x] `golangci-lint run ./internal/cmd/`
- [ ] CI green (lint, build, unit, envtest, e2e)