### PR TITLE
fix: avoid panics on malformed metrics quantities and pod status shapes

### DIFF
--- a/internal/tools/format.go
+++ b/internal/tools/format.go
@@ -126,15 +126,11 @@ func podStatus(obj map[string]interface{}) string {
 		if !ok {
 			continue
 		}
-		if waiting, ok := cm["state"].(map[string]interface{})["waiting"].(map[string]interface{}); ok {
-			if reason, ok := waiting["reason"].(string); ok && reason != "" {
-				return reason
-			}
+		if reason := containerStateReason(cm, "waiting"); reason != "" {
+			return reason
 		}
-		if terminated, ok := cm["state"].(map[string]interface{})["terminated"].(map[string]interface{}); ok {
-			if reason, ok := terminated["reason"].(string); ok && reason != "" {
-				return reason
-			}
+		if reason := containerStateReason(cm, "terminated"); reason != "" {
+			return reason
 		}
 	}
 
@@ -145,14 +141,28 @@ func podStatus(obj map[string]interface{}) string {
 		if !ok {
 			continue
 		}
-		if waiting, ok := cm["state"].(map[string]interface{})["waiting"].(map[string]interface{}); ok {
-			if reason, ok := waiting["reason"].(string); ok && reason != "" {
-				return "Init:" + reason
-			}
+		if reason := containerStateReason(cm, "waiting"); reason != "" {
+			return "Init:" + reason
 		}
 	}
 
 	return phase
+}
+
+// containerStateReason safely extracts .state.<stateKey>.reason from a single
+// containerStatus map. It returns "" when any level is missing or not the
+// expected type, avoiding panics on unexpected status shapes.
+func containerStateReason(cm map[string]interface{}, stateKey string) string {
+	state, ok := cm["state"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	sub, ok := state[stateKey].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	reason, _ := sub["reason"].(string)
+	return reason
 }
 
 func podReady(obj map[string]interface{}) string {

--- a/internal/tools/format_test.go
+++ b/internal/tools/format_test.go
@@ -411,6 +411,42 @@ func TestPodStatus(t *testing.T) {
 			},
 			want: "Pending",
 		},
+		{
+			name: "container status without state does not panic",
+			obj: map[string]interface{}{
+				"status": map[string]interface{}{
+					"phase": "Running",
+					"containerStatuses": []interface{}{
+						map[string]interface{}{"name": "app"},
+					},
+				},
+			},
+			want: "Running",
+		},
+		{
+			name: "non-map state is skipped without panicking",
+			obj: map[string]interface{}{
+				"status": map[string]interface{}{
+					"phase": "Running",
+					"containerStatuses": []interface{}{
+						map[string]interface{}{"state": "unexpected-string"},
+					},
+				},
+			},
+			want: "Running",
+		},
+		{
+			name: "empty state object falls back to phase",
+			obj: map[string]interface{}{
+				"status": map[string]interface{}{
+					"phase": "Running",
+					"containerStatuses": []interface{}{
+						map[string]interface{}{"state": map[string]interface{}{}},
+					},
+				},
+			},
+			want: "Running",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/tools/top.go
+++ b/internal/tools/top.go
@@ -24,14 +24,22 @@ var (
 )
 
 // formatCPU converts a Kubernetes CPU quantity string to human-readable millicores.
+// Returns the raw value unchanged when it cannot be parsed as a quantity.
 func formatCPU(raw string) string {
-	q := resource.MustParse(raw)
+	q, err := resource.ParseQuantity(raw)
+	if err != nil {
+		return raw
+	}
 	return fmt.Sprintf("%dm", q.MilliValue())
 }
 
 // formatMemory converts a Kubernetes memory quantity string to human-readable MiB.
+// Returns the raw value unchanged when it cannot be parsed as a quantity.
 func formatMemory(raw string) string {
-	q := resource.MustParse(raw)
+	q, err := resource.ParseQuantity(raw)
+	if err != nil {
+		return raw
+	}
 	mib := q.Value() / (1024 * 1024)
 	return fmt.Sprintf("%dMi", mib)
 }
@@ -209,12 +217,14 @@ func sumContainerUsage(obj map[string]interface{}) (cpuMillis int64, memBytes in
 			continue
 		}
 		if cpu, ok := usage["cpu"].(string); ok {
-			q := resource.MustParse(cpu)
-			cpuMillis += q.MilliValue()
+			if q, err := resource.ParseQuantity(cpu); err == nil {
+				cpuMillis += q.MilliValue()
+			}
 		}
 		if mem, ok := usage["memory"].(string); ok {
-			q := resource.MustParse(mem)
-			memBytes += q.Value()
+			if q, err := resource.ParseQuantity(mem); err == nil {
+				memBytes += q.Value()
+			}
 		}
 	}
 	return cpuMillis, memBytes
@@ -246,12 +256,14 @@ func eachContainerUsage(obj map[string]interface{}) []containerMetric {
 		var m containerMetric
 		m.name = name
 		if cpu, ok := usage["cpu"].(string); ok {
-			q := resource.MustParse(cpu)
-			m.cpuMillis = q.MilliValue()
+			if q, err := resource.ParseQuantity(cpu); err == nil {
+				m.cpuMillis = q.MilliValue()
+			}
 		}
 		if mem, ok := usage["memory"].(string); ok {
-			q := resource.MustParse(mem)
-			m.memBytes = q.Value()
+			if q, err := resource.ParseQuantity(mem); err == nil {
+				m.memBytes = q.Value()
+			}
 		}
 		result = append(result, m)
 	}
@@ -373,12 +385,14 @@ func registerTopNodes(s *server.MCPServer, pool *kube.ClientPool) {
 
 			var cpuMillis, memBytes int64
 			if cpu, ok := usage["cpu"].(string); ok {
-				q := resource.MustParse(cpu)
-				cpuMillis = q.MilliValue()
+				if q, err := resource.ParseQuantity(cpu); err == nil {
+					cpuMillis = q.MilliValue()
+				}
 			}
 			if mem, ok := usage["memory"].(string); ok {
-				q := resource.MustParse(mem)
-				memBytes = q.Value()
+				if q, err := resource.ParseQuantity(mem); err == nil {
+					memBytes = q.Value()
+				}
 			}
 
 			alloc := allocatable[m.GetName()]
@@ -420,12 +434,14 @@ func extractAllocatable(obj map[string]interface{}) nodeAllocatable {
 
 	var result nodeAllocatable
 	if cpu, ok := alloc["cpu"].(string); ok {
-		q := resource.MustParse(cpu)
-		result.cpuMillis = q.MilliValue()
+		if q, err := resource.ParseQuantity(cpu); err == nil {
+			result.cpuMillis = q.MilliValue()
+		}
 	}
 	if mem, ok := alloc["memory"].(string); ok {
-		q := resource.MustParse(mem)
-		result.memBytes = q.Value()
+		if q, err := resource.ParseQuantity(mem); err == nil {
+			result.memBytes = q.Value()
+		}
 	}
 	return result
 }

--- a/internal/tools/top_test.go
+++ b/internal/tools/top_test.go
@@ -159,6 +159,8 @@ func TestFormatCPU(t *testing.T) {
 		{"1", "1000m"},
 		{"1500m", "1500m"},
 		{"100m", "100m"},
+		{"garbage", "garbage"}, // unparseable: returned unchanged, no panic
+		{"", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
@@ -180,6 +182,8 @@ func TestFormatMemory(t *testing.T) {
 		{"65536Ki", "64Mi"},
 		{"128Mi", "128Mi"},
 		{"0", "0Mi"},
+		{"not-a-quantity", "not-a-quantity"}, // unparseable: returned unchanged, no panic
+		{"", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
@@ -208,6 +212,63 @@ func TestFormatPercent(t *testing.T) {
 				t.Errorf("formatPercent(%d, %d) = %q, want %q", tt.used, tt.alloc, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSumContainerUsage_MalformedQuantitySkipped(t *testing.T) {
+	obj := map[string]interface{}{
+		"containers": []interface{}{
+			map[string]interface{}{
+				"name":  "good",
+				"usage": map[string]interface{}{"cpu": "100m", "memory": "64Mi"},
+			},
+			map[string]interface{}{
+				"name":  "bad",
+				"usage": map[string]interface{}{"cpu": "garbage", "memory": "also-bad"},
+			},
+		},
+	}
+
+	cpuMillis, memBytes := sumContainerUsage(obj)
+	if cpuMillis != 100 {
+		t.Errorf("cpuMillis = %d, want 100 (malformed container skipped)", cpuMillis)
+	}
+	if memBytes != 64*1024*1024 {
+		t.Errorf("memBytes = %d, want %d (malformed container skipped)", memBytes, 64*1024*1024)
+	}
+}
+
+func TestEachContainerUsage_MalformedQuantitySkipped(t *testing.T) {
+	obj := map[string]interface{}{
+		"containers": []interface{}{
+			map[string]interface{}{
+				"name":  "bad",
+				"usage": map[string]interface{}{"cpu": "nope", "memory": "nope"},
+			},
+		},
+	}
+
+	metrics := eachContainerUsage(obj)
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(metrics))
+	}
+	if metrics[0].cpuMillis != 0 || metrics[0].memBytes != 0 {
+		t.Errorf("malformed quantities should yield zero usage, got cpu=%d mem=%d",
+			metrics[0].cpuMillis, metrics[0].memBytes)
+	}
+}
+
+func TestExtractAllocatable_MalformedQuantitySkipped(t *testing.T) {
+	obj := map[string]interface{}{
+		"status": map[string]interface{}{
+			"allocatable": map[string]interface{}{"cpu": "bogus", "memory": "bogus"},
+		},
+	}
+
+	alloc := extractAllocatable(obj)
+	if alloc.cpuMillis != 0 || alloc.memBytes != 0 {
+		t.Errorf("malformed allocatable should yield zero, got cpu=%d mem=%d",
+			alloc.cpuMillis, alloc.memBytes)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two reachable panic sources in read-only tool handlers (would previously crash the process; `WithRecovery` from #35 now contains them, but the root causes should still be removed):

1. **`top_pods` / `top_nodes` (`top.go`)** — every CPU/memory value from the metrics API and Node `.status.allocatable` was parsed with `resource.MustParse`, which **panics** on any unparseable quantity. A malformed value from a third-party `metrics.k8s.io` adapter (or an unexpected type) would panic the handler. All 8 call sites now use `resource.ParseQuantity`: `formatCPU`/`formatMemory` return the raw value on error; the summing/extraction helpers skip the bad value.

2. **`podStatus` (`format.go`)** — used an unchecked nested type assertion `cm["state"].(map[string]interface{})["waiting"]` that panics when a `containerStatus` has no map-typed `state`. Reachable via `list_resources` summary format. Extracted a safe `containerStateReason` helper that returns `""` for missing or wrong-typed levels.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./internal/tools/` (added cases: unparseable quantities skipped/returned-raw; container status without `state`, non-map `state`, empty `state` → no panic, falls back to phase)
- [x] `golangci-lint run ./internal/tools/`
- [ ] CI green