### PR TITLE
fix: prevent goroutine leak in follow-logs on timeout

### DIFF
--- a/internal/tools/logs.go
+++ b/internal/tools/logs.go
@@ -278,15 +278,27 @@ func readFollowStream(r io.Reader, timeout time.Duration) (lines []string, trunc
 	}
 
 	ch := make(chan lineMsg)
+	// done unblocks the scanning goroutine when the consumer stops reading
+	// (timeout or buffer cap) while the goroutine is parked on a channel send.
+	// Without it the goroutine would leak permanently on every timed-out follow.
+	done := make(chan struct{})
+	defer close(done)
 
 	go func() {
 		defer close(ch)
 		scanner := bufio.NewScanner(r)
 		for scanner.Scan() {
-			ch <- lineMsg{text: scanner.Text()}
+			select {
+			case ch <- lineMsg{text: scanner.Text()}:
+			case <-done:
+				return
+			}
 		}
 		if scanErr := scanner.Err(); scanErr != nil {
-			ch <- lineMsg{err: scanErr}
+			select {
+			case ch <- lineMsg{err: scanErr}:
+			case <-done:
+			}
 		}
 	}()
 

--- a/internal/tools/logs_test.go
+++ b/internal/tools/logs_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -399,5 +400,56 @@ func TestGetLogs_ReadFollowStream_BufferCapBytes(t *testing.T) {
 	_, truncated, _ := readFollowStream(pr, 5*time.Second)
 	if !truncated {
 		t.Error("expected truncation flag when > 1MB read")
+	}
+}
+
+// repeatReader is an infinite, non-blocking io.Reader that endlessly repeats
+// data. It never returns EOF and never blocks, so the scanning goroutine in
+// readFollowStream is only ever scanning or parked on a channel send — exactly
+// the condition under which the timeout/cap return path must not leak it.
+type repeatReader struct {
+	data []byte
+	off  int
+}
+
+func (r *repeatReader) Read(p []byte) (int, error) {
+	n := 0
+	for n < len(p) {
+		if r.off >= len(r.data) {
+			r.off = 0
+		}
+		c := copy(p[n:], r.data[r.off:])
+		n += c
+		r.off += c
+	}
+	return n, nil
+}
+
+// TestGetLogs_ReadFollowStream_NoGoroutineLeak verifies that the scanning
+// goroutine exits after readFollowStream returns, even when the source never
+// closes and the goroutine is parked on a channel send at return time.
+func TestGetLogs_ReadFollowStream_NoGoroutineLeak(t *testing.T) {
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	r := &repeatReader{data: []byte("a line of log output\n")}
+	lines, _, _ := readFollowStream(r, 50*time.Millisecond)
+	if len(lines) == 0 {
+		t.Fatal("expected to accumulate at least one line")
+	}
+
+	// The internal scanning goroutine must terminate shortly after the call
+	// returns. With the leak it stays blocked on the channel send forever.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if runtime.NumGoroutine() <= baseline {
+			return // goroutine cleaned up
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("scanning goroutine leaked: goroutines=%d, baseline=%d",
+				runtime.NumGoroutine(), baseline)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
## Summary

`readFollowStream` (used by `get_logs follow=true`) sends each scanned line on an **unbuffered** channel. When the consumer stops reading — `followTimeout` fired or the 10k-line / 1MB cap was hit — while the scanning goroutine is parked on a send, the goroutine blocks there **forever**. `fetchFollowLogs` calls `cancel()` + `stream.Close()` afterward, but that only unblocks a goroutine sitting in `scanner.Scan()`, not one already blocked on the channel send. Result: one leaked goroutine (holding the log stream) per timed-out follow call — and the multi-pod path calls this once per pod.

The fix adds a `done` channel, closed via `defer` on every return path, and has the goroutine `select` on send-vs-`done` so it always unwinds.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./internal/tools/`
- [x] New regression test `TestGetLogs_ReadFollowStream_NoGoroutineLeak` — verified it **fails** against the previous implementation (goroutine count stays elevated) and passes with the fix
- [x] `golangci-lint run ./internal/tools/`
- [ ] CI green