### PR TITLE
fix: validate node name to prevent apiserver path traversal in node_logs/node_stats

### DIFF
--- a/internal/tools/node_logs.go
+++ b/internal/tools/node_logs.go
@@ -51,6 +51,11 @@ func registerNodeLogs(s *server.MCPServer, pool *kube.ClientPool) {
 		logPath := req.GetString("logPath", "")
 		tail := int64(req.GetFloat("tail", 0))
 
+		// Validate node name to prevent apiserver path traversal.
+		if err := validateNodeName(node); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
 		// Validate logPath to prevent path traversal.
 		if err := validateLogPath(logPath); err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
@@ -136,6 +141,21 @@ func formatDirListing(logPath string, links []string) string {
 
 	sb.WriteString("\nUse one of these paths as the logPath parameter to view the log content.")
 	return sb.String()
+}
+
+// validateNodeName rejects node names that could reshape the apiserver request
+// path (e.g. containing '/' or '..'). Real Kubernetes node names are DNS
+// subdomains and never contain these characters. Without this check, a crafted
+// node value could reach other apiserver GET endpoints (such as secrets) that
+// bypass this server's secret redaction.
+func validateNodeName(n string) error {
+	if n == "" {
+		return fmt.Errorf("node is required")
+	}
+	if strings.ContainsAny(n, "/\\") || strings.Contains(n, "..") {
+		return fmt.Errorf("invalid node name %q", n)
+	}
+	return nil
 }
 
 // validateLogPath checks for path traversal attempts in the log path.

--- a/internal/tools/node_logs_test.go
+++ b/internal/tools/node_logs_test.go
@@ -123,6 +123,53 @@ func TestNodeLogs_ValidatesLogPath(t *testing.T) {
 	}
 }
 
+func TestNodeLogs_ValidatesNodeName(t *testing.T) {
+	cfg := defaultCfg()
+	pool := buildNodeLogsPool(cfg)
+
+	handler := getHandler(t, "node_logs", func(s *server.MCPServer) {
+		registerNodeLogs(s, pool)
+	})
+
+	res, err := handler(context.Background(), callToolReq(map[string]any{
+		"node": "../../secrets",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !res.IsError {
+		t.Error("expected error for bogus node name")
+	}
+	text := resultText(t, res)
+	if !strings.Contains(text, "invalid node name") {
+		t.Errorf("expected invalid node name error, got: %s", text)
+	}
+}
+
+func TestValidateNodeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		nodeName string
+		wantErr  bool
+	}{
+		{"valid name", "node-1", false},
+		{"empty", "", true},
+		{"contains slash", "nodes/foo", true},
+		{"contains double dot", "../../secrets", true},
+		{"contains backslash", `node\1`, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNodeName(tt.nodeName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateNodeName(%q) error = %v, wantErr %v", tt.nodeName, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestIsHTMLDirListing(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/tools/node_stats.go
+++ b/internal/tools/node_stats.go
@@ -42,6 +42,11 @@ func registerNodeStats(s *server.MCPServer, pool *kube.ClientPool) {
 
 		node, _ := req.RequireString("node")
 
+		// Validate node name to prevent apiserver path traversal.
+		if err := validateNodeName(node); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
 		absPath := "/api/v1/nodes/" + node + "/proxy/stats/summary"
 		stream, err := cc.Clientset.CoreV1().RESTClient().Get().AbsPath(absPath).Stream(ctx)
 		if err != nil {

--- a/internal/tools/node_stats_test.go
+++ b/internal/tools/node_stats_test.go
@@ -1,9 +1,36 @@
 package tools
 
 import (
+	"context"
 	"strings"
 	"testing"
+
+	"github.com/mark3labs/mcp-go/server"
 )
+
+func TestNodeStats_ValidatesNodeName(t *testing.T) {
+	cfg := defaultCfg()
+	pool := buildNodeLogsPool(cfg)
+
+	handler := getHandler(t, "node_stats", func(s *server.MCPServer) {
+		registerNodeStats(s, pool)
+	})
+
+	res, err := handler(context.Background(), callToolReq(map[string]any{
+		"node": "../../secrets",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !res.IsError {
+		t.Error("expected error for bogus node name")
+	}
+	text := resultText(t, res)
+	if !strings.Contains(text, "invalid node name") {
+		t.Errorf("expected invalid node name error, got: %s", text)
+	}
+}
 
 func TestFormatNodeStats(t *testing.T) {
 	rawJSON := `{


### PR DESCRIPTION
## Summary

The user-supplied `node` parameter was interpolated directly into the Kubernetes apiserver path in both tools:

- `node_logs`: `/api/v1/nodes/<node>/proxy/logs/`
- `node_stats`: `/api/v1/nodes/<node>/proxy/stats/summary`

`logPath` was already validated against `..` and leading `/`, but `node` was **not** validated. A crafted node value containing `/` and `..` segments could reshape the request path to reach other apiserver GET endpoints (e.g. `secrets`), which return data **without** this server's secret redaction. Real Kubernetes node names are DNS subdomains and never contain `/` or `..`.

### Fix

- Add a shared `validateNodeName` helper (next to `validateLogPath` in `node_logs.go`) that rejects empty names and any name containing `/`, `\`, or `..`.
- Call it in **both** `node_logs` and `node_stats` immediately after reading `node`, before constructing the apiserver path.
- Errors are returned as `mcp.NewToolResultError(err.Error()), nil`, matching the existing `validateLogPath` pattern.

## Test plan

- [x] `TestValidateNodeName` — table-driven unit test: valid name, empty, `/`, `..`, backslash.
- [x] `TestNodeLogs_ValidatesNodeName` — handler-level test asserting `../../secrets` returns an error result.
- [x] `TestNodeStats_ValidatesNodeName` — handler-level test asserting `../../secrets` returns an error result.
- [x] `go build ./...`
- [x] `go test -race -count=1 ./internal/tools/`
- [x] `golangci-lint run ./internal/tools/` — 0 issues