### PR TITLE
fix: reject list_resources format=table for Secrets when redaction is enabled

### DIFF
--- a/internal/tools/handlers_test.go
+++ b/internal/tools/handlers_test.go
@@ -1096,6 +1096,29 @@ func TestListResourcesFormatParameter(t *testing.T) {
 		}
 	})
 
+	t.Run("table+Secret with redaction returns error", func(t *testing.T) {
+		sec := testSecret("table-secret", "default")
+		secPool := buildPool(cfg, defaultRawConfig(), newFakeDynClient(sec), fake.NewClientset())
+		h := getHandler(t, "list_resources", func(s *server.MCPServer) {
+			registerListResources(s, secPool, cfg)
+		})
+		res, err := h(context.Background(), callToolReq(map[string]any{
+			"kind":      "Secret",
+			"namespace": "default",
+			"format":    "table",
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !res.IsError {
+			t.Fatalf("expected error for table+Secret with redaction enabled, got: %s", resultText(t, res))
+		}
+		text := resultText(t, res)
+		if !strings.Contains(text, "Secrets") || !strings.Contains(text, "redaction") {
+			t.Errorf("expected error mentioning Secrets and redaction, got: %s", text)
+		}
+	})
+
 	t.Run("format=summary returns summary output", func(t *testing.T) {
 		res, err := handler(context.Background(), callToolReq(map[string]any{
 			"kind":   "Pod",

--- a/internal/tools/list.go
+++ b/internal/tools/list.go
@@ -141,6 +141,15 @@ func registerListResources(s *server.MCPServer, pool *kube.ClientPool, cfg *conf
 			opts.Continue = continueToken
 		}
 
+		// Table format bypasses RedactSecretsList (it returns server-side Table
+		// output directly), so reject it for Secrets while redaction is enabled
+		// to preserve the redaction guarantee.
+		if format == "table" && !cfg.AllowSecrets && gvr.Group == "" && gvr.Resource == "secrets" {
+			return mcp.NewToolResultError(
+				"format=table is not supported for Secrets while redaction is enabled (it would bypass secret redaction); use format=summary or format=json, or start the server with secrets allowed",
+			), nil
+		}
+
 		// Table format uses the server-side Table API directly.
 		if format == "table" {
 			return handleListTable(ctx, cc, gvr, namespace, opts)


### PR DESCRIPTION
## Summary

The `list_resources` handler applies `kube.RedactSecretsList` only on the JSON and summary paths (`list.go`). The `format=table` path returns the server-side Table API output directly via `handleListTable`/`fetchTableList`, bypassing redaction entirely.

By default the server-side Table for Secrets exposes only metadata columns (NAME/TYPE/DATA/AGE — DATA is a count, not values), so there is no confirmed value leak today. But it is the one read path that bypasses the redaction guarantee, which is fragile.

This is a defense-in-depth fix: when the resolved resource is core `secrets` AND redaction is on (`!cfg.AllowSecrets`), reject `format=table` with a clear, actionable error instead of silently bypassing redaction. The guard is placed after `gvr` is resolved and before the `handleListTable` dispatch. Rendered table cells are intentionally NOT redacted (out of scope, fragile) — the reject-guard is the agreed approach.

## Test plan

- [x] `go build ./...`
- [x] `go test -race -count=1 ./internal/tools/`
- [x] `golangci-lint run ./internal/tools/`
- [x] New subtest `TestListResourcesFormatParameter/table+Secret with redaction returns error` asserts the handler returns an error mentioning Secrets and redaction when `kind=Secret` + `format=table` under default (redaction-enabled) config.
- [x] Existing `format=table`+filter and non-Secret format paths remain unaffected.