### PR TITLE
fix: correct drain_node timeout docs to match actual eviction semantics

### DIFF
--- a/internal/tools/drain.go
+++ b/internal/tools/drain.go
@@ -50,8 +50,10 @@ func registerDrainNode(s *server.MCPServer, pool *kube.ClientPool, cfg *config.C
 				"WARNING: these unmanaged pods will be deleted and permanently lost (default: false)"),
 		),
 		mcp.WithNumber("timeout",
-			mcp.Description("Maximum seconds to wait for all pods to be evicted. 0 means wait indefinitely (default: 0). "+
-				"If the timeout is reached, the tool returns an error listing remaining pods."),
+			mcp.Description("Maximum seconds to spend issuing eviction requests for the node's pods. 0 means no limit (default: 0). "+
+				"Eviction is asynchronous: this bounds the time to REQUEST eviction of all eligible pods, not the time for them to "+
+				"actually terminate. If the timeout is reached before every pod has had an eviction requested, the tool returns an "+
+				"error listing the pods that were not yet processed."),
 		),
 	)
 
@@ -121,9 +123,11 @@ func registerDrainNode(s *server.MCPServer, pool *kube.ClientPool, cfg *config.C
 		var errors []string
 
 		for i := range pods.Items {
-			// Check timeout before processing each pod.
+			// Check timeout before processing each pod. The timeout bounds the
+			// time spent ISSUING eviction requests, not the time for pods to
+			// terminate (eviction is asynchronous).
 			if !deadline.IsZero() && time.Now().After(deadline) {
-				// Collect remaining pod names for the timeout error message.
+				// Collect the pods that had no eviction requested yet.
 				var remaining []string
 				for j := i; j < len(pods.Items); j++ {
 					p := &pods.Items[j]
@@ -136,7 +140,7 @@ func registerDrainNode(s *server.MCPServer, pool *kube.ClientPool, cfg *config.C
 					remaining = append(remaining, fmt.Sprintf("%s/%s", p.Namespace, p.Name))
 				}
 				return mcp.NewToolResultError(fmt.Sprintf(
-					"drain timed out after %.3gs waiting for pods to be evicted; remaining pods: %s",
+					"drain timed out after %.3gs while issuing eviction requests; pods not yet processed: %s",
 					timeoutFloat, strings.Join(remaining, ", "),
 				)), nil
 			}

--- a/internal/tools/drain_test.go
+++ b/internal/tools/drain_test.go
@@ -423,13 +423,15 @@ func TestDrainNode_ForceFalse_UnmanagedPodError(t *testing.T) {
 	}
 }
 
-// TestDrainNode_Timeout verifies that timeout>0 returns an error listing
-// remaining pods when the deadline expires before all pods are processed.
+// TestDrainNode_Timeout verifies that timeout>0 returns an error listing the
+// pods that had no eviction requested when the deadline expires before all
+// pods are processed.
 //
-// The drain loop checks the deadline at the top of each iteration. The test
-// uses two pods and makes the first eviction block for 100ms while the
-// timeout is set to 50ms, so the deadline expires before the second pod is
-// attempted.
+// The timeout bounds the time spent ISSUING eviction requests (eviction is
+// asynchronous), not the time for pods to terminate. The drain loop checks the
+// deadline at the top of each iteration. The test uses two pods and makes the
+// first eviction block for 100ms while the timeout is set to 50ms, so the
+// deadline expires before the second pod is attempted.
 func TestDrainNode_Timeout(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.AllowWrite = true
@@ -482,8 +484,55 @@ func TestDrainNode_Timeout(t *testing.T) {
 	if !strings.Contains(text, "timed out") {
 		t.Errorf("expected 'timed out' in error, got: %s", text)
 	}
+	// The error must describe the actual (issuing-eviction) semantics rather
+	// than claiming it waited for pods to terminate.
+	if !strings.Contains(text, "issuing eviction requests") {
+		t.Errorf("expected error to describe issuing-eviction semantics, got: %s", text)
+	}
 	if !strings.Contains(text, "slow-pod") {
-		t.Errorf("expected remaining pod in timeout error, got: %s", text)
+		t.Errorf("expected unprocessed pod in timeout error, got: %s", text)
+	}
+}
+
+// TestDrainNode_TimeoutDescription_HonestAboutSemantics verifies that the
+// timeout parameter description accurately states it bounds the time to ISSUE
+// eviction requests (eviction is asynchronous) rather than falsely claiming it
+// waits for pods to terminate.
+func TestDrainNode_TimeoutDescription_HonestAboutSemantics(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.AllowWrite = true
+	cfg.AllowDestructive = true
+
+	fakeCS := fake.NewClientset()
+	dynClient := newWriteFakeDynClient()
+	pool := buildWritePool(cfg, dynClient, fakeCS)
+
+	s := server.NewMCPServer("test", "0.1.0", server.WithToolCapabilities(false))
+	registerDrainNode(s, pool, cfg)
+
+	tool := s.GetTool("drain_node")
+	if tool == nil {
+		t.Fatal("drain_node tool not found")
+	}
+
+	timeoutDesc := ""
+	if props := tool.Tool.InputSchema.Properties; props != nil {
+		if raw, ok := props["timeout"].(map[string]any); ok {
+			timeoutDesc, _ = raw["description"].(string)
+		}
+	}
+	if timeoutDesc == "" {
+		t.Fatal("timeout parameter has no description")
+	}
+
+	descLower := strings.ToLower(timeoutDesc)
+	// Must honestly describe that it bounds issuing eviction requests.
+	if !strings.Contains(descLower, "issuing eviction") {
+		t.Errorf("timeout description should state it bounds issuing eviction requests, got: %s", timeoutDesc)
+	}
+	// Must NOT claim it waits for all pods to be evicted/terminated.
+	if strings.Contains(descLower, "wait for all pods to be evicted") {
+		t.Errorf("timeout description must not falsely claim it waits for all pods to be evicted, got: %s", timeoutDesc)
 	}
 }
 


### PR DESCRIPTION
## Summary

The `drain_node` `timeout` parameter was documented as *"Maximum seconds to wait for all pods to be evicted. ... If the timeout is reached, the tool returns an error listing remaining pods."* — but this contract was never met.

`EvictV1` is fire-and-forget: it **requests** eviction and returns immediately, without waiting for the pod to actually terminate. The drain loop only checks `time.Now().After(deadline)` once per pod before issuing the next eviction, so the timeout effectively bounds the time to **issue** evictions (near-instant) rather than the time for pods to be gone. Behavior did not match the documented contract.

### Fix chosen: documentation honesty (option A)

I deliberately did **not** add a blocking termination poll (option B) because:

- `timeout=0` means "no limit", and a fire-and-forget standalone pod (as used by the e2e `drain_and_uncordon` test) can linger after eviction is requested — an unbounded poll there risks hanging the e2e suite.
- The existing `TestDrainNode_Timeout` unit test is built around the current deadline-per-iteration semantics; option B would require reworking it.

Instead this makes behavior and docs internally consistent:

- The `timeout` description now states it bounds the time to **request** eviction of all eligible pods (eviction is asynchronous), not the time for them to terminate.
- The timeout error message now reads `"drain timed out after Ns while issuing eviction requests; pods not yet processed: ..."`.

No behavior change for callers; only string wording and one new test.

## Test plan

- [x] `go build ./...`
- [x] `go test -race -count=1 ./internal/tools/` (all 15 `TestDrainNode_*` pass)
- [x] `golangci-lint run ./internal/tools/` (0 issues)
- [x] New `TestDrainNode_TimeoutDescription_HonestAboutSemantics` asserts the description no longer falsely claims to wait for termination
- [x] `TestDrainNode_Timeout` tightened to assert the corrected error phrasing (`issuing eviction requests`)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>