### PR TITLE
chore: add go fix pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,13 @@ repos:
         types: [go]
         pass_filenames: false
 
+      - id: go-fix
+        name: go fix
+        entry: go fix ./...
+        language: system
+        types: [go]
+        pass_filenames: false
+
       - id: go-vet
         name: go vet
         entry: go vet ./...

--- a/internal/cmd/serve_test.go
+++ b/internal/cmd/serve_test.go
@@ -201,9 +201,9 @@ func TestServerInstructions_InInitializeResponse(t *testing.T) {
 	// The streamable-HTTP response is SSE-formatted. Extract the JSON-RPC
 	// result by scanning for the data line.
 	var resultJSON []byte
-	for _, line := range strings.Split(string(body), "\n") {
-		if strings.HasPrefix(line, "data: ") {
-			resultJSON = []byte(strings.TrimPrefix(line, "data: "))
+	for line := range strings.SplitSeq(string(body), "\n") {
+		if after, ok := strings.CutPrefix(line, "data: "); ok {
+			resultJSON = []byte(after)
 			break
 		}
 	}

--- a/internal/kube/filter.go
+++ b/internal/kube/filter.go
@@ -28,7 +28,7 @@ func redactMapValues(obj *unstructured.Unstructured, field string) {
 	if !ok {
 		return
 	}
-	m, ok := raw.(map[string]interface{})
+	m, ok := raw.(map[string]any)
 	if !ok {
 		return
 	}

--- a/internal/kube/filter_test.go
+++ b/internal/kube/filter_test.go
@@ -1,20 +1,19 @@
 package kube
 
 import (
+	"maps"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func newUnstructured(kind string, fields map[string]interface{}) *unstructured.Unstructured {
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+func newUnstructured(kind string, fields map[string]any) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       kind,
-		"metadata":   map[string]interface{}{"name": "test", "namespace": "default"},
+		"metadata":   map[string]any{"name": "test", "namespace": "default"},
 	}}
-	for k, v := range fields {
-		obj.Object[k] = v
-	}
+	maps.Copy(obj.Object, fields)
 	return obj
 }
 
@@ -26,14 +25,14 @@ func TestRedactSecrets(t *testing.T) {
 	}{
 		{
 			name: "secret with data and stringData gets redacted",
-			obj: newUnstructured("Secret", map[string]interface{}{
-				"data":       map[string]interface{}{"token": "c2VjcmV0", "key": "dmFsdWU="},
-				"stringData": map[string]interface{}{"password": "hunter2"},
+			obj: newUnstructured("Secret", map[string]any{
+				"data":       map[string]any{"token": "c2VjcmV0", "key": "dmFsdWU="},
+				"stringData": map[string]any{"password": "hunter2"},
 			}),
 			check: func(t *testing.T, obj *unstructured.Unstructured) {
 				t.Helper()
 				for _, field := range []string{"data", "stringData"} {
-					m, ok := obj.Object[field].(map[string]interface{})
+					m, ok := obj.Object[field].(map[string]any)
 					if !ok {
 						t.Fatalf("expected %s to be a map", field)
 					}
@@ -47,12 +46,12 @@ func TestRedactSecrets(t *testing.T) {
 		},
 		{
 			name: "non-Secret is untouched",
-			obj: newUnstructured("ConfigMap", map[string]interface{}{
-				"data": map[string]interface{}{"key": "value"},
+			obj: newUnstructured("ConfigMap", map[string]any{
+				"data": map[string]any{"key": "value"},
 			}),
 			check: func(t *testing.T, obj *unstructured.Unstructured) {
 				t.Helper()
-				m := obj.Object["data"].(map[string]interface{})
+				m := obj.Object["data"].(map[string]any)
 				if m["key"] != "value" {
 					t.Errorf("data[key] = %v, want value", m["key"])
 				}
@@ -73,7 +72,7 @@ func TestRedactSecrets(t *testing.T) {
 		},
 		{
 			name: "secret with non-map data field",
-			obj: newUnstructured("Secret", map[string]interface{}{
+			obj: newUnstructured("Secret", map[string]any{
 				"data": "not-a-map",
 			}),
 			check: func(t *testing.T, obj *unstructured.Unstructured) {
@@ -94,14 +93,14 @@ func TestRedactSecrets(t *testing.T) {
 }
 
 func TestRedactSecretsList(t *testing.T) {
-	secret := newUnstructured("Secret", map[string]interface{}{
-		"data": map[string]interface{}{"token": "c2VjcmV0"},
+	secret := newUnstructured("Secret", map[string]any{
+		"data": map[string]any{"token": "c2VjcmV0"},
 	})
-	configMap := newUnstructured("ConfigMap", map[string]interface{}{
-		"data": map[string]interface{}{"key": "value"},
+	configMap := newUnstructured("ConfigMap", map[string]any{
+		"data": map[string]any{"key": "value"},
 	})
-	secret2 := newUnstructured("Secret", map[string]interface{}{
-		"stringData": map[string]interface{}{"pass": "s3cret"},
+	secret2 := newUnstructured("Secret", map[string]any{
+		"stringData": map[string]any{"pass": "s3cret"},
 	})
 
 	list := &unstructured.UnstructuredList{
@@ -111,19 +110,19 @@ func TestRedactSecretsList(t *testing.T) {
 	RedactSecretsList(list)
 
 	// First item: Secret data redacted
-	m := list.Items[0].Object["data"].(map[string]interface{})
+	m := list.Items[0].Object["data"].(map[string]any)
 	if m["token"] != redactedValue {
 		t.Errorf("Items[0] data[token] = %v, want %s", m["token"], redactedValue)
 	}
 
 	// Second item: ConfigMap untouched
-	m = list.Items[1].Object["data"].(map[string]interface{})
+	m = list.Items[1].Object["data"].(map[string]any)
 	if m["key"] != "value" {
 		t.Errorf("Items[1] data[key] = %v, want value", m["key"])
 	}
 
 	// Third item: Secret stringData redacted
-	m = list.Items[2].Object["stringData"].(map[string]interface{})
+	m = list.Items[2].Object["stringData"].(map[string]any)
 	if m["pass"] != redactedValue {
 		t.Errorf("Items[2] stringData[pass] = %v, want %s", m["pass"], redactedValue)
 	}
@@ -138,13 +137,13 @@ func TestRedactMapValues(t *testing.T) {
 	}{
 		{
 			name: "map present is redacted",
-			obj: newUnstructured("Secret", map[string]interface{}{
-				"data": map[string]interface{}{"a": "1", "b": "2"},
+			obj: newUnstructured("Secret", map[string]any{
+				"data": map[string]any{"a": "1", "b": "2"},
 			}),
 			field: "data",
 			check: func(t *testing.T, obj *unstructured.Unstructured) {
 				t.Helper()
-				m := obj.Object["data"].(map[string]interface{})
+				m := obj.Object["data"].(map[string]any)
 				for k, v := range m {
 					if v != redactedValue {
 						t.Errorf("data[%s] = %v, want %s", k, v, redactedValue)
@@ -165,7 +164,7 @@ func TestRedactMapValues(t *testing.T) {
 		},
 		{
 			name: "non-map value is not modified",
-			obj: newUnstructured("Secret", map[string]interface{}{
+			obj: newUnstructured("Secret", map[string]any{
 				"data": "a-string",
 			}),
 			field: "data",

--- a/internal/mcplog/contextlog_test.go
+++ b/internal/mcplog/contextlog_test.go
@@ -201,7 +201,7 @@ func TestContextLogWriter_ConcurrentAccess(t *testing.T) {
 	defer func() { _ = clw.Close() }()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
@@ -213,7 +213,7 @@ func TestContextLogWriter_ConcurrentAccess(t *testing.T) {
 	wg.Wait()
 
 	// Verify all 5 context files were created.
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		logFile := filepath.Join(clw.Dir(), fmt.Sprintf("ctx-%d.log", i))
 		if _, err := os.Stat(logFile); err != nil {
 			t.Errorf("expected log file %s to exist: %v", logFile, err)

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -16,14 +16,14 @@ func TestLimiter_AllowsUnderLimit(t *testing.T) {
 func TestLimiter_RejectsWhenExhausted(t *testing.T) {
 	l := NewLimiter(10) // 10/min, burst = max(5, 10/6) = 5
 	// Drain all burst tokens.
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		if !l.Allow() {
 			t.Fatalf("call %d should succeed within burst", i+1)
 		}
 	}
 	// Rapidly exhaust — without waiting, subsequent calls should fail.
 	rejected := false
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		if !l.Allow() {
 			rejected = true
 			break
@@ -36,7 +36,7 @@ func TestLimiter_RejectsWhenExhausted(t *testing.T) {
 
 func TestLimiter_ZeroMeansUnlimited(t *testing.T) {
 	l := NewLimiter(0)
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		if !l.Allow() {
 			t.Fatalf("Allow() returned false at iteration %d with unlimited limiter", i)
 		}
@@ -45,7 +45,7 @@ func TestLimiter_ZeroMeansUnlimited(t *testing.T) {
 
 func TestLimiter_NegativeMeansUnlimited(t *testing.T) {
 	l := NewLimiter(-5)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		if !l.Allow() {
 			t.Fatalf("Allow() returned false with negative rate")
 		}
@@ -77,7 +77,7 @@ func TestLimiter_DenyMessageUnlimited(t *testing.T) {
 func TestLimiter_BurstAllowsLLMParallelCalls(t *testing.T) {
 	// Write limiter at 30/min should allow at least 5 rapid calls (burst=5).
 	l := NewLimiter(30)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		if !l.Allow() {
 			t.Fatalf("call %d should succeed within burst for 30/min limiter", i+1)
 		}
@@ -85,7 +85,7 @@ func TestLimiter_BurstAllowsLLMParallelCalls(t *testing.T) {
 
 	// Read limiter at 120/min should allow at least 15 rapid calls (burst=20).
 	l2 := NewLimiter(120)
-	for i := 0; i < 15; i++ {
+	for i := range 15 {
 		if !l2.Allow() {
 			t.Fatalf("call %d should succeed within burst for 120/min limiter", i+1)
 		}
@@ -95,12 +95,10 @@ func TestLimiter_BurstAllowsLLMParallelCalls(t *testing.T) {
 func TestLimiter_ConcurrentAccess(t *testing.T) {
 	l := NewLimiter(1000)
 	var wg sync.WaitGroup
-	for i := 0; i < 50; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 50 {
+		wg.Go(func() {
 			_ = l.Allow()
-		}()
+		})
 	}
 	wg.Wait()
 	// No race condition — test passes if no panic.

--- a/internal/ratelimit/middleware_test.go
+++ b/internal/ratelimit/middleware_test.go
@@ -35,7 +35,7 @@ func TestWrap_ReturnsErrorWhenRateLimited(t *testing.T) {
 
 	// Subsequent calls should be rate limited.
 	var rateLimited bool
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		res, err := wrapped(context.Background(), mcp.CallToolRequest{})
 		if err != nil {
 			t.Fatal(err)
@@ -56,7 +56,7 @@ func TestWrap_ReturnsErrorWhenRateLimited(t *testing.T) {
 func TestWrap_NilLimiterPassesThrough(t *testing.T) {
 	wrapped := Wrap(dummyHandler, nil)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		res, err := wrapped(context.Background(), mcp.CallToolRequest{})
 		if err != nil {
 			t.Fatal(err)
@@ -71,7 +71,7 @@ func TestWrap_UnlimitedLimiterPassesThrough(t *testing.T) {
 	l := NewLimiter(0) // unlimited
 	wrapped := Wrap(dummyHandler, l)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		res, err := wrapped(context.Background(), mcp.CallToolRequest{})
 		if err != nil {
 			t.Fatal(err)

--- a/internal/resources/handler.go
+++ b/internal/resources/handler.go
@@ -85,14 +85,14 @@ func fetchResource(
 // stripNoise removes managedFields and last-applied-configuration annotation
 // to reduce payload size.
 func stripNoise(obj *unstructured.Unstructured) {
-	meta, ok := obj.Object["metadata"].(map[string]interface{})
+	meta, ok := obj.Object["metadata"].(map[string]any)
 	if !ok {
 		return
 	}
 
 	delete(meta, "managedFields")
 
-	annotations, ok := meta["annotations"].(map[string]interface{})
+	annotations, ok := meta["annotations"].(map[string]any)
 	if ok {
 		delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")
 		if len(annotations) == 0 {

--- a/internal/resources/handler_test.go
+++ b/internal/resources/handler_test.go
@@ -47,38 +47,38 @@ func testPool(dynClient *fakedynamic.FakeDynamicClient) *kube.ClientPool {
 }
 
 func testConfigMap(name, ns string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "ConfigMap",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name,
 			"namespace": ns,
 		},
-		"data": map[string]interface{}{
+		"data": map[string]any{
 			"key": "value",
 		},
 	}}
 }
 
 func testSecret(name, ns string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Secret",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name,
 			"namespace": ns,
 		},
-		"data": map[string]interface{}{
+		"data": map[string]any{
 			"password": "c2VjcmV0",
 		},
 	}}
 }
 
 func testNode(name string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Node",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name": name,
 		},
 	}}
@@ -212,11 +212,11 @@ func TestReadResource_NotFound(t *testing.T) {
 }
 
 func TestStripNoise(t *testing.T) {
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{
-		"metadata": map[string]interface{}{
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
 			"name":          "test",
-			"managedFields": []interface{}{"something"},
-			"annotations": map[string]interface{}{
+			"managedFields": []any{"something"},
+			"annotations": map[string]any{
 				"kubectl.kubernetes.io/last-applied-configuration": "{}",
 				"app.kubernetes.io/name":                           "test",
 			},
@@ -225,11 +225,11 @@ func TestStripNoise(t *testing.T) {
 
 	stripNoise(obj)
 
-	meta := obj.Object["metadata"].(map[string]interface{})
+	meta := obj.Object["metadata"].(map[string]any)
 	if _, ok := meta["managedFields"]; ok {
 		t.Error("managedFields should have been stripped")
 	}
-	annotations := meta["annotations"].(map[string]interface{})
+	annotations := meta["annotations"].(map[string]any)
 	if _, ok := annotations["kubectl.kubernetes.io/last-applied-configuration"]; ok {
 		t.Error("last-applied-configuration should have been stripped")
 	}
@@ -239,10 +239,10 @@ func TestStripNoise(t *testing.T) {
 }
 
 func TestStripNoise_EmptyAnnotations(t *testing.T) {
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{
-		"metadata": map[string]interface{}{
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
 			"name": "test",
-			"annotations": map[string]interface{}{
+			"annotations": map[string]any{
 				"kubectl.kubernetes.io/last-applied-configuration": "{}",
 			},
 		},
@@ -250,7 +250,7 @@ func TestStripNoise_EmptyAnnotations(t *testing.T) {
 
 	stripNoise(obj)
 
-	meta := obj.Object["metadata"].(map[string]interface{})
+	meta := obj.Object["metadata"].(map[string]any)
 	if _, ok := meta["annotations"]; ok {
 		t.Error("empty annotations map should have been removed")
 	}

--- a/internal/tools/api_resources.go
+++ b/internal/tools/api_resources.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -127,8 +128,8 @@ func collectAPIResources(
 // groupFromGV extracts the API group from a GroupVersion string.
 // For "v1" (core), returns "". For "apps/v1", returns "apps".
 func groupFromGV(gv string) string {
-	if idx := strings.Index(gv, "/"); idx >= 0 {
-		return gv[:idx]
+	if before, _, ok := strings.Cut(gv, "/"); ok {
+		return before
 	}
 	return ""
 }
@@ -161,12 +162,7 @@ func matchVerb(verbs []string, filter string) bool {
 	if filter == "" {
 		return true
 	}
-	for _, v := range verbs {
-		if v == filter {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(verbs, filter)
 }
 
 // formatAPIResourcesTable renders entries as a compact columnar table.
@@ -209,16 +205,16 @@ func formatAPIResourcesJSON(entries []apiResourceEntry) (*mcp.CallToolResult, er
 	}
 
 	// Build structuredContent as an object envelope.
-	items := make([]map[string]interface{}, 0, len(entries))
+	items := make([]map[string]any, 0, len(entries))
 	for _, e := range entries {
-		items = append(items, map[string]interface{}{
+		items = append(items, map[string]any{
 			"kind":       e.Kind,
 			"apiVersion": e.APIVersion,
 			"namespaced": e.Namespaced,
 			"verbs":      e.Verbs,
 		})
 	}
-	envelope := map[string]interface{}{
+	envelope := map[string]any{
 		"items": items,
 		"count": len(items),
 	}

--- a/internal/tools/apply_test.go
+++ b/internal/tools/apply_test.go
@@ -702,17 +702,17 @@ func TestScaleResource_SafetyDelayApplied(t *testing.T) {
 
 // testDaemonSet returns an unstructured DaemonSet object.
 func testDaemonSet(name, ns string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "apps/v1",
 		"kind":       "DaemonSet",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              name,
 			"namespace":         ns,
 			"creationTimestamp": "2024-01-01T00:00:00Z",
 		},
-		"spec": map[string]interface{}{
-			"template": map[string]interface{}{
-				"metadata": map[string]interface{}{},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"metadata": map[string]any{},
 			},
 		},
 	}}

--- a/internal/tools/cleanup_pods.go
+++ b/internal/tools/cleanup_pods.go
@@ -102,7 +102,7 @@ type podCleanupEntry struct {
 // parseStates parses a comma-separated list of state names into a lookup set.
 func parseStates(s string) map[string]bool {
 	states := make(map[string]bool)
-	for _, part := range strings.Split(s, ",") {
+	for part := range strings.SplitSeq(s, ",") {
 		part = strings.TrimSpace(part)
 		if part != "" {
 			states[part] = true

--- a/internal/tools/cleanup_pods_test.go
+++ b/internal/tools/cleanup_pods_test.go
@@ -13,14 +13,14 @@ import (
 )
 
 func testPodWithStatus(name, ns, phase, reason string) *unstructured.Unstructured {
-	status := map[string]interface{}{"phase": phase}
+	status := map[string]any{"phase": phase}
 	if reason != "" {
 		status["reason"] = reason
 	}
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Pod",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              name,
 			"namespace":         ns,
 			"creationTimestamp": "2024-01-01T00:00:00Z",

--- a/internal/tools/create.go
+++ b/internal/tools/create.go
@@ -159,7 +159,7 @@ func splitYAMLDocuments(manifest string) []string {
 	normalized := strings.ReplaceAll(manifest, "\r\n", "\n")
 	var docs []string
 	var current strings.Builder
-	for _, line := range strings.Split(normalized, "\n") {
+	for line := range strings.SplitSeq(normalized, "\n") {
 		if strings.TrimSpace(line) == "---" {
 			docs = append(docs, current.String())
 			current.Reset()

--- a/internal/tools/describe.go
+++ b/internal/tools/describe.go
@@ -125,7 +125,7 @@ func registerDescribeResource(s *server.MCPServer, pool *kube.ClientPool, cfg *c
 			fmt.Fprintf(&sb, "\nConditions:\n")
 			fmt.Fprintf(&sb, "  %-25s %-10s %-25s %s\n", "TYPE", "STATUS", "REASON", "MESSAGE")
 			for _, c := range conditions {
-				cm, ok := c.(map[string]interface{})
+				cm, ok := c.(map[string]any)
 				if !ok {
 					continue
 				}
@@ -143,7 +143,7 @@ func registerDescribeResource(s *server.MCPServer, pool *kube.ClientPool, cfg *c
 			specYAML, err := yaml.Marshal(spec)
 			if err == nil {
 				fmt.Fprintf(&sb, "\nSpec:\n")
-				for _, line := range strings.Split(string(specYAML), "\n") {
+				for line := range strings.SplitSeq(string(specYAML), "\n") {
 					if line != "" {
 						fmt.Fprintf(&sb, "  %s\n", line)
 					}
@@ -161,7 +161,7 @@ func registerDescribeResource(s *server.MCPServer, pool *kube.ClientPool, cfg *c
 	})
 }
 
-func unstructuredNestedSlice(obj map[string]interface{}, fields ...string) ([]interface{}, bool, error) {
+func unstructuredNestedSlice(obj map[string]any, fields ...string) ([]any, bool, error) {
 	current := obj
 	for i, field := range fields {
 		val, ok := current[field]
@@ -169,10 +169,10 @@ func unstructuredNestedSlice(obj map[string]interface{}, fields ...string) ([]in
 			return nil, false, nil
 		}
 		if i == len(fields)-1 {
-			slice, ok := val.([]interface{})
+			slice, ok := val.([]any)
 			return slice, ok, nil
 		}
-		next, ok := val.(map[string]interface{})
+		next, ok := val.(map[string]any)
 		if !ok {
 			return nil, false, nil
 		}
@@ -181,7 +181,7 @@ func unstructuredNestedSlice(obj map[string]interface{}, fields ...string) ([]in
 	return nil, false, nil
 }
 
-func mapStr(m map[string]interface{}, key string) string {
+func mapStr(m map[string]any, key string) string {
 	v, ok := m[key]
 	if !ok {
 		return ""

--- a/internal/tools/describe_helpers_test.go
+++ b/internal/tools/describe_helpers_test.go
@@ -7,17 +7,17 @@ import (
 func TestUnstructuredNestedSlice(t *testing.T) {
 	tests := []struct {
 		name      string
-		obj       map[string]interface{}
+		obj       map[string]any
 		fields    []string
 		wantLen   int
 		wantFound bool
 	}{
 		{
 			name: "valid path",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
-					"conditions": []interface{}{
-						map[string]interface{}{"type": "Ready"},
+			obj: map[string]any{
+				"status": map[string]any{
+					"conditions": []any{
+						map[string]any{"type": "Ready"},
 					},
 				},
 			},
@@ -27,15 +27,15 @@ func TestUnstructuredNestedSlice(t *testing.T) {
 		},
 		{
 			name:      "missing field",
-			obj:       map[string]interface{}{},
+			obj:       map[string]any{},
 			fields:    []string{"status", "conditions"},
 			wantLen:   0,
 			wantFound: false,
 		},
 		{
 			name: "non-slice type at leaf",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
+			obj: map[string]any{
+				"status": map[string]any{
 					"conditions": "not-a-slice",
 				},
 			},
@@ -45,7 +45,7 @@ func TestUnstructuredNestedSlice(t *testing.T) {
 		},
 		{
 			name: "intermediate non-map",
-			obj: map[string]interface{}{
+			obj: map[string]any{
 				"status": "string-not-map",
 			},
 			fields:    []string{"status", "conditions"},
@@ -54,8 +54,8 @@ func TestUnstructuredNestedSlice(t *testing.T) {
 		},
 		{
 			name: "single field path",
-			obj: map[string]interface{}{
-				"items": []interface{}{"a", "b"},
+			obj: map[string]any{
+				"items": []any{"a", "b"},
 			},
 			fields:    []string{"items"},
 			wantLen:   2,
@@ -63,7 +63,7 @@ func TestUnstructuredNestedSlice(t *testing.T) {
 		},
 		{
 			name:      "empty fields returns nil (no iteration)",
-			obj:       map[string]interface{}{"a": "b"},
+			obj:       map[string]any{"a": "b"},
 			fields:    []string{},
 			wantLen:   0,
 			wantFound: false,
@@ -87,10 +87,10 @@ func TestUnstructuredNestedSlice(t *testing.T) {
 }
 
 func TestMapStr(t *testing.T) {
-	m := map[string]interface{}{
+	m := map[string]any{
 		"type":   "Ready",
 		"count":  42,
-		"nested": map[string]interface{}{"a": "b"},
+		"nested": map[string]any{"a": "b"},
 	}
 
 	tests := []struct {

--- a/internal/tools/exec.go
+++ b/internal/tools/exec.go
@@ -114,10 +114,7 @@ func registerExecPod(s *server.MCPServer, pool *kube.ClientPool, runner ExecRunn
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		timeout := time.Duration(req.GetFloat("timeout", defaultExecTimeout.Seconds())) * time.Second
-		if timeout > maxExecTimeout {
-			timeout = maxExecTimeout
-		}
+		timeout := min(time.Duration(req.GetFloat("timeout", defaultExecTimeout.Seconds()))*time.Second, maxExecTimeout)
 		if timeout <= 0 {
 			timeout = defaultExecTimeout
 		}

--- a/internal/tools/explain.go
+++ b/internal/tools/explain.go
@@ -115,11 +115,11 @@ func registerExplainResource(s *server.MCPServer, pool *kube.ClientPool) {
 // "Deployment.spec.replicas" -> ("Deployment", "spec.replicas")
 // "Pod" -> ("Pod", "")
 func parseResourcePath(s string) (string, string) {
-	idx := strings.IndexByte(s, '.')
-	if idx < 0 {
+	before, after, ok := strings.Cut(s, ".")
+	if !ok {
 		return s, ""
 	}
-	return s[:idx], s[idx+1:]
+	return before, after
 }
 
 // findAPIResource looks up the metav1.APIResource for the given GVR.

--- a/internal/tools/explain_schema.go
+++ b/internal/tools/explain_schema.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 
@@ -158,9 +159,7 @@ func resolveSchema(s openAPISchema, schemas map[string]openAPISchema) openAPISch
 				if merged.Properties == nil {
 					merged.Properties = make(map[string]openAPISchema)
 				}
-				for k, v := range resolved.Properties {
-					merged.Properties[k] = v
-				}
+				maps.Copy(merged.Properties, resolved.Properties)
 			}
 			if resolved.Required != nil {
 				merged.Required = append(merged.Required, resolved.Required...)

--- a/internal/tools/explain_test.go
+++ b/internal/tools/explain_test.go
@@ -33,7 +33,7 @@ func TestExplainResource_SimpleKind(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}
@@ -68,7 +68,7 @@ func TestExplainResource_WithApiVersion(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}
@@ -103,7 +103,7 @@ func TestExplainResource_DottedPath(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}
@@ -183,12 +183,12 @@ func TestExplainResource_ContainsVerbs(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}
 
-	verbs, ok := result["verbs"].([]interface{})
+	verbs, ok := result["verbs"].([]any)
 	if !ok {
 		t.Fatal("expected verbs array")
 	}

--- a/internal/tools/format.go
+++ b/internal/tools/format.go
@@ -13,13 +13,13 @@ import (
 // formatResourceList returns a JSON array of resource summaries.
 // Each resource kind gets tailored fields so the LLM can reason
 // over them without text parsing.
-func formatResourceList(items []unstructured.Unstructured) (string, []map[string]interface{}, error) {
+func formatResourceList(items []unstructured.Unstructured) (string, []map[string]any, error) {
 	if len(items) == 0 {
 		return "[]", nil, nil
 	}
 
 	kind := items[0].GetKind()
-	summaries := make([]map[string]interface{}, 0, len(items))
+	summaries := make([]map[string]any, 0, len(items))
 
 	for _, item := range items {
 		s := baseFields(item)
@@ -49,8 +49,8 @@ func formatResourceList(items []unstructured.Unstructured) (string, []map[string
 	return string(out), summaries, nil
 }
 
-func baseFields(item unstructured.Unstructured) map[string]interface{} {
-	m := map[string]interface{}{
+func baseFields(item unstructured.Unstructured) map[string]any {
+	m := map[string]any{
 		"name": item.GetName(),
 		"age":  resourceAge(item),
 	}
@@ -60,14 +60,14 @@ func baseFields(item unstructured.Unstructured) map[string]interface{} {
 	return m
 }
 
-func enrichPod(s map[string]interface{}, obj map[string]interface{}) {
+func enrichPod(s map[string]any, obj map[string]any) {
 	s["status"] = podStatus(obj)
 	s["ready"] = podReady(obj)
 	s["restarts"] = podRestarts(obj)
 	s["node"] = getStrField(obj, "spec", "nodeName")
 }
 
-func enrichDeployment(s map[string]interface{}, obj map[string]interface{}) {
+func enrichDeployment(s map[string]any, obj map[string]any) {
 	replicas := getIntField(obj, "spec", "replicas")
 	ready := getIntField(obj, "status", "readyReplicas")
 	s["ready"] = fmt.Sprintf("%d/%d", ready, replicas)
@@ -75,19 +75,19 @@ func enrichDeployment(s map[string]interface{}, obj map[string]interface{}) {
 	s["available"] = getIntField(obj, "status", "availableReplicas")
 }
 
-func enrichStatefulSet(s map[string]interface{}, obj map[string]interface{}) {
+func enrichStatefulSet(s map[string]any, obj map[string]any) {
 	replicas := getIntField(obj, "spec", "replicas")
 	ready := getIntField(obj, "status", "readyReplicas")
 	s["ready"] = fmt.Sprintf("%d/%d", ready, replicas)
 }
 
-func enrichDaemonSet(s map[string]interface{}, obj map[string]interface{}) {
+func enrichDaemonSet(s map[string]any, obj map[string]any) {
 	s["desired"] = getIntField(obj, "status", "desiredNumberScheduled")
 	s["ready"] = getIntField(obj, "status", "numberReady")
 	s["available"] = getIntField(obj, "status", "numberAvailable")
 }
 
-func enrichJob(s map[string]interface{}, obj map[string]interface{}) {
+func enrichJob(s map[string]any, obj map[string]any) {
 	succeeded := getIntField(obj, "status", "succeeded")
 	completions := getIntField(obj, "spec", "completions")
 	s["completions"] = fmt.Sprintf("%d/%d", succeeded, completions)
@@ -100,7 +100,7 @@ func enrichJob(s map[string]interface{}, obj map[string]interface{}) {
 	s["status"] = status
 }
 
-func enrichNode(s map[string]interface{}, item unstructured.Unstructured) {
+func enrichNode(s map[string]any, item unstructured.Unstructured) {
 	status := "NotReady"
 	if conditionIsTrue(item.Object, "Ready") {
 		status = "Ready"
@@ -109,20 +109,20 @@ func enrichNode(s map[string]interface{}, item unstructured.Unstructured) {
 	s["roles"] = nodeRoles(item.GetLabels())
 }
 
-func enrichService(s map[string]interface{}, obj map[string]interface{}) {
+func enrichService(s map[string]any, obj map[string]any) {
 	s["type"] = getStrField(obj, "spec", "type")
 	s["clusterIP"] = getStrField(obj, "spec", "clusterIP")
 }
 
 // --- Pod helpers ---
 
-func podStatus(obj map[string]interface{}) string {
+func podStatus(obj map[string]any) string {
 	phase := getStrField(obj, "status", "phase")
 
 	// Check for container-level overrides (CrashLoopBackOff, etc.)
 	containerStatuses, _, _ := nestedSlice(obj, "status", "containerStatuses")
 	for _, cs := range containerStatuses {
-		cm, ok := cs.(map[string]interface{})
+		cm, ok := cs.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -137,7 +137,7 @@ func podStatus(obj map[string]interface{}) string {
 	// Check init containers too.
 	initStatuses, _, _ := nestedSlice(obj, "status", "initContainerStatuses")
 	for _, cs := range initStatuses {
-		cm, ok := cs.(map[string]interface{})
+		cm, ok := cs.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -152,12 +152,12 @@ func podStatus(obj map[string]interface{}) string {
 // containerStateReason safely extracts .state.<stateKey>.reason from a single
 // containerStatus map. It returns "" when any level is missing or not the
 // expected type, avoiding panics on unexpected status shapes.
-func containerStateReason(cm map[string]interface{}, stateKey string) string {
-	state, ok := cm["state"].(map[string]interface{})
+func containerStateReason(cm map[string]any, stateKey string) string {
+	state, ok := cm["state"].(map[string]any)
 	if !ok {
 		return ""
 	}
-	sub, ok := state[stateKey].(map[string]interface{})
+	sub, ok := state[stateKey].(map[string]any)
 	if !ok {
 		return ""
 	}
@@ -165,12 +165,12 @@ func containerStateReason(cm map[string]interface{}, stateKey string) string {
 	return reason
 }
 
-func podReady(obj map[string]interface{}) string {
+func podReady(obj map[string]any) string {
 	containerStatuses, _, _ := nestedSlice(obj, "status", "containerStatuses")
 	total := len(containerStatuses)
 	ready := 0
 	for _, cs := range containerStatuses {
-		cm, ok := cs.(map[string]interface{})
+		cm, ok := cs.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -181,11 +181,11 @@ func podReady(obj map[string]interface{}) string {
 	return fmt.Sprintf("%d/%d", ready, total)
 }
 
-func podRestarts(obj map[string]interface{}) string {
+func podRestarts(obj map[string]any) string {
 	containerStatuses, _, _ := nestedSlice(obj, "status", "containerStatuses")
 	total := 0
 	for _, cs := range containerStatuses {
-		cm, ok := cs.(map[string]interface{})
+		cm, ok := cs.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -208,10 +208,10 @@ func resourceAge(item unstructured.Unstructured) string {
 	return duration.HumanDuration(metav1.Now().Sub(ts.Time))
 }
 
-func getStrField(obj map[string]interface{}, keys ...string) string {
-	current := interface{}(obj)
+func getStrField(obj map[string]any, keys ...string) string {
+	current := any(obj)
 	for _, k := range keys {
-		m, ok := current.(map[string]interface{})
+		m, ok := current.(map[string]any)
 		if !ok {
 			return ""
 		}
@@ -227,10 +227,10 @@ func getStrField(obj map[string]interface{}, keys ...string) string {
 	return s
 }
 
-func getIntField(obj map[string]interface{}, keys ...string) int64 {
-	current := interface{}(obj)
+func getIntField(obj map[string]any, keys ...string) int64 {
+	current := any(obj)
 	for _, k := range keys {
-		m, ok := current.(map[string]interface{})
+		m, ok := current.(map[string]any)
 		if !ok {
 			return 0
 		}
@@ -249,10 +249,10 @@ func getIntField(obj map[string]interface{}, keys ...string) int64 {
 	}
 }
 
-func conditionIsTrue(obj map[string]interface{}, condType string) bool {
+func conditionIsTrue(obj map[string]any, condType string) bool {
 	conditions, _, _ := nestedSlice(obj, "status", "conditions")
 	for _, c := range conditions {
-		cm, ok := c.(map[string]interface{})
+		cm, ok := c.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -265,10 +265,10 @@ func conditionIsTrue(obj map[string]interface{}, condType string) bool {
 	return false
 }
 
-func nestedSlice(obj map[string]interface{}, keys ...string) ([]interface{}, bool, error) {
-	current := interface{}(obj)
+func nestedSlice(obj map[string]any, keys ...string) ([]any, bool, error) {
+	current := any(obj)
 	for _, k := range keys {
-		m, ok := current.(map[string]interface{})
+		m, ok := current.(map[string]any)
 		if !ok {
 			return nil, false, nil
 		}
@@ -277,15 +277,15 @@ func nestedSlice(obj map[string]interface{}, keys ...string) ([]interface{}, boo
 			return nil, false, nil
 		}
 	}
-	s, ok := current.([]interface{})
+	s, ok := current.([]any)
 	return s, ok, nil
 }
 
 func nodeRoles(labels map[string]string) string {
 	var roles []string
 	for k := range labels {
-		if strings.HasPrefix(k, "node-role.kubernetes.io/") {
-			role := strings.TrimPrefix(k, "node-role.kubernetes.io/")
+		if after, ok := strings.CutPrefix(k, "node-role.kubernetes.io/"); ok {
+			role := after
 			if role != "" {
 				roles = append(roles, role)
 			}

--- a/internal/tools/format_test.go
+++ b/internal/tools/format_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"encoding/json"
+	"maps"
 	"strings"
 	"testing"
 	"time"
@@ -11,21 +12,19 @@ import (
 )
 
 // makeUnstructured is a test helper that builds an Unstructured object.
-func makeUnstructured(kind, name, namespace string, extra map[string]interface{}) unstructured.Unstructured {
-	obj := map[string]interface{}{
+func makeUnstructured(kind, name, namespace string, extra map[string]any) unstructured.Unstructured {
+	obj := map[string]any{
 		"apiVersion": "v1",
 		"kind":       kind,
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              name,
 			"creationTimestamp": metav1.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339),
 		},
 	}
 	if namespace != "" {
-		obj["metadata"].(map[string]interface{})["namespace"] = namespace
+		obj["metadata"].(map[string]any)["namespace"] = namespace
 	}
-	for k, v := range extra {
-		obj[k] = v
-	}
+	maps.Copy(obj, extra)
 	return unstructured.Unstructured{Object: obj}
 }
 
@@ -41,18 +40,18 @@ func TestFormatResourceList_Empty(t *testing.T) {
 
 func TestFormatResourceList_Pod(t *testing.T) {
 	items := []unstructured.Unstructured{
-		makeUnstructured("Pod", "nginx", "default", map[string]interface{}{
-			"status": map[string]interface{}{
+		makeUnstructured("Pod", "nginx", "default", map[string]any{
+			"status": map[string]any{
 				"phase": "Running",
-				"containerStatuses": []interface{}{
-					map[string]interface{}{
+				"containerStatuses": []any{
+					map[string]any{
 						"ready":        true,
 						"restartCount": int64(0),
-						"state":        map[string]interface{}{},
+						"state":        map[string]any{},
 					},
 				},
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"nodeName": "node-1",
 			},
 		}),
@@ -61,7 +60,7 @@ func TestFormatResourceList_Pod(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var parsed []map[string]interface{}
+	var parsed []map[string]any
 	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
@@ -81,16 +80,16 @@ func TestFormatResourceList_Pod(t *testing.T) {
 
 func TestFormatResourceList_Deployment(t *testing.T) {
 	items := []unstructured.Unstructured{
-		makeUnstructured("Deployment", "web", "default", map[string]interface{}{
-			"spec":   map[string]interface{}{"replicas": int64(3)},
-			"status": map[string]interface{}{"readyReplicas": int64(3), "updatedReplicas": int64(3), "availableReplicas": int64(3)},
+		makeUnstructured("Deployment", "web", "default", map[string]any{
+			"spec":   map[string]any{"replicas": int64(3)},
+			"status": map[string]any{"readyReplicas": int64(3), "updatedReplicas": int64(3), "availableReplicas": int64(3)},
 		}),
 	}
 	got, _, err := formatResourceList(items)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var parsed []map[string]interface{}
+	var parsed []map[string]any
 	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
 		t.Fatal(err)
 	}
@@ -101,16 +100,16 @@ func TestFormatResourceList_Deployment(t *testing.T) {
 
 func TestFormatResourceList_StatefulSet(t *testing.T) {
 	items := []unstructured.Unstructured{
-		makeUnstructured("StatefulSet", "db", "default", map[string]interface{}{
-			"spec":   map[string]interface{}{"replicas": int64(3)},
-			"status": map[string]interface{}{"readyReplicas": int64(2)},
+		makeUnstructured("StatefulSet", "db", "default", map[string]any{
+			"spec":   map[string]any{"replicas": int64(3)},
+			"status": map[string]any{"readyReplicas": int64(2)},
 		}),
 	}
 	got, _, err := formatResourceList(items)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var parsed []map[string]interface{}
+	var parsed []map[string]any
 	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
 		t.Fatal(err)
 	}
@@ -121,8 +120,8 @@ func TestFormatResourceList_StatefulSet(t *testing.T) {
 
 func TestFormatResourceList_DaemonSet(t *testing.T) {
 	items := []unstructured.Unstructured{
-		makeUnstructured("DaemonSet", "agent", "kube-system", map[string]interface{}{
-			"status": map[string]interface{}{
+		makeUnstructured("DaemonSet", "agent", "kube-system", map[string]any{
+			"status": map[string]any{
 				"desiredNumberScheduled": int64(5),
 				"numberReady":            int64(5),
 				"numberAvailable":        int64(5),
@@ -133,7 +132,7 @@ func TestFormatResourceList_DaemonSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var parsed []map[string]interface{}
+	var parsed []map[string]any
 	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +144,7 @@ func TestFormatResourceList_DaemonSet(t *testing.T) {
 func TestFormatResourceList_Job(t *testing.T) {
 	tests := []struct {
 		name       string
-		conditions []interface{}
+		conditions []any
 		wantStatus string
 	}{
 		{
@@ -155,15 +154,15 @@ func TestFormatResourceList_Job(t *testing.T) {
 		},
 		{
 			name: "complete",
-			conditions: []interface{}{
-				map[string]interface{}{"type": "Complete", "status": "True"},
+			conditions: []any{
+				map[string]any{"type": "Complete", "status": "True"},
 			},
 			wantStatus: "Complete",
 		},
 		{
 			name: "failed",
-			conditions: []interface{}{
-				map[string]interface{}{"type": "Failed", "status": "True"},
+			conditions: []any{
+				map[string]any{"type": "Failed", "status": "True"},
 			},
 			wantStatus: "Failed",
 		},
@@ -171,13 +170,13 @@ func TestFormatResourceList_Job(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			status := map[string]interface{}{"succeeded": int64(1)}
+			status := map[string]any{"succeeded": int64(1)}
 			if tt.conditions != nil {
 				status["conditions"] = tt.conditions
 			}
 			items := []unstructured.Unstructured{
-				makeUnstructured("Job", "batch-job", "default", map[string]interface{}{
-					"spec":   map[string]interface{}{"completions": int64(1)},
+				makeUnstructured("Job", "batch-job", "default", map[string]any{
+					"spec":   map[string]any{"completions": int64(1)},
 					"status": status,
 				}),
 			}
@@ -185,7 +184,7 @@ func TestFormatResourceList_Job(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			var parsed []map[string]interface{}
+			var parsed []map[string]any
 			if err := json.Unmarshal([]byte(got), &parsed); err != nil {
 				t.Fatal(err)
 			}
@@ -199,24 +198,24 @@ func TestFormatResourceList_Job(t *testing.T) {
 func TestFormatResourceList_Node(t *testing.T) {
 	tests := []struct {
 		name       string
-		labels     map[string]interface{}
-		conditions []interface{}
+		labels     map[string]any
+		conditions []any
 		wantStatus string
 		wantRoles  string
 	}{
 		{
 			name:   "ready with roles",
-			labels: map[string]interface{}{"node-role.kubernetes.io/control-plane": ""},
-			conditions: []interface{}{
-				map[string]interface{}{"type": "Ready", "status": "True"},
+			labels: map[string]any{"node-role.kubernetes.io/control-plane": ""},
+			conditions: []any{
+				map[string]any{"type": "Ready", "status": "True"},
 			},
 			wantStatus: "Ready",
 			wantRoles:  "control-plane",
 		},
 		{
 			name:       "not ready no roles",
-			labels:     map[string]interface{}{},
-			conditions: []interface{}{},
+			labels:     map[string]any{},
+			conditions: []any{},
 			wantStatus: "NotReady",
 			wantRoles:  "<none>",
 		},
@@ -224,22 +223,22 @@ func TestFormatResourceList_Node(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			obj := map[string]interface{}{
+			obj := map[string]any{
 				"apiVersion": "v1",
 				"kind":       "Node",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":              "node-1",
 					"labels":            tt.labels,
 					"creationTimestamp": metav1.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339),
 				},
-				"status": map[string]interface{}{"conditions": tt.conditions},
+				"status": map[string]any{"conditions": tt.conditions},
 			}
 			items := []unstructured.Unstructured{{Object: obj}}
 			got, _, err := formatResourceList(items)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			var parsed []map[string]interface{}
+			var parsed []map[string]any
 			if err := json.Unmarshal([]byte(got), &parsed); err != nil {
 				t.Fatal(err)
 			}
@@ -265,15 +264,15 @@ func TestFormatResourceList_Service(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			items := []unstructured.Unstructured{
-				makeUnstructured("Service", "svc", "default", map[string]interface{}{
-					"spec": map[string]interface{}{"type": tt.svcType, "clusterIP": tt.ip},
+				makeUnstructured("Service", "svc", "default", map[string]any{
+					"spec": map[string]any{"type": tt.svcType, "clusterIP": tt.ip},
 				}),
 			}
 			got, _, err := formatResourceList(items)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			var parsed []map[string]interface{}
+			var parsed []map[string]any
 			if err := json.Unmarshal([]byte(got), &parsed); err != nil {
 				t.Fatal(err)
 			}
@@ -295,7 +294,7 @@ func TestFormatResourceList_UnknownKind(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var parsed []map[string]interface{}
+	var parsed []map[string]any
 	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
 		t.Fatal(err)
 	}
@@ -332,25 +331,25 @@ func TestBaseFields(t *testing.T) {
 func TestPodStatus(t *testing.T) {
 	tests := []struct {
 		name string
-		obj  map[string]interface{}
+		obj  map[string]any
 		want string
 	}{
 		{
 			name: "phase only",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{"phase": "Running"},
+			obj: map[string]any{
+				"status": map[string]any{"phase": "Running"},
 			},
 			want: "Running",
 		},
 		{
 			name: "CrashLoopBackOff overrides phase",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
+			obj: map[string]any{
+				"status": map[string]any{
 					"phase": "Running",
-					"containerStatuses": []interface{}{
-						map[string]interface{}{
-							"state": map[string]interface{}{
-								"waiting": map[string]interface{}{"reason": "CrashLoopBackOff"},
+					"containerStatuses": []any{
+						map[string]any{
+							"state": map[string]any{
+								"waiting": map[string]any{"reason": "CrashLoopBackOff"},
 							},
 						},
 					},
@@ -360,13 +359,13 @@ func TestPodStatus(t *testing.T) {
 		},
 		{
 			name: "terminated reason overrides phase",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
+			obj: map[string]any{
+				"status": map[string]any{
 					"phase": "Failed",
-					"containerStatuses": []interface{}{
-						map[string]interface{}{
-							"state": map[string]interface{}{
-								"terminated": map[string]interface{}{"reason": "OOMKilled"},
+					"containerStatuses": []any{
+						map[string]any{
+							"state": map[string]any{
+								"terminated": map[string]any{"reason": "OOMKilled"},
 							},
 						},
 					},
@@ -376,14 +375,14 @@ func TestPodStatus(t *testing.T) {
 		},
 		{
 			name: "init container waiting",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
+			obj: map[string]any{
+				"status": map[string]any{
 					"phase":             "Pending",
-					"containerStatuses": []interface{}{},
-					"initContainerStatuses": []interface{}{
-						map[string]interface{}{
-							"state": map[string]interface{}{
-								"waiting": map[string]interface{}{"reason": "ImagePullBackOff"},
+					"containerStatuses": []any{},
+					"initContainerStatuses": []any{
+						map[string]any{
+							"state": map[string]any{
+								"waiting": map[string]any{"reason": "ImagePullBackOff"},
 							},
 						},
 					},
@@ -393,31 +392,31 @@ func TestPodStatus(t *testing.T) {
 		},
 		{
 			name: "non-map container status is skipped",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
+			obj: map[string]any{
+				"status": map[string]any{
 					"phase":             "Running",
-					"containerStatuses": []interface{}{"not-a-map"},
+					"containerStatuses": []any{"not-a-map"},
 				},
 			},
 			want: "Running",
 		},
 		{
 			name: "non-map init container status is skipped",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
+			obj: map[string]any{
+				"status": map[string]any{
 					"phase":                 "Pending",
-					"initContainerStatuses": []interface{}{"not-a-map"},
+					"initContainerStatuses": []any{"not-a-map"},
 				},
 			},
 			want: "Pending",
 		},
 		{
 			name: "container status without state does not panic",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
+			obj: map[string]any{
+				"status": map[string]any{
 					"phase": "Running",
-					"containerStatuses": []interface{}{
-						map[string]interface{}{"name": "app"},
+					"containerStatuses": []any{
+						map[string]any{"name": "app"},
 					},
 				},
 			},
@@ -425,11 +424,11 @@ func TestPodStatus(t *testing.T) {
 		},
 		{
 			name: "non-map state is skipped without panicking",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
+			obj: map[string]any{
+				"status": map[string]any{
 					"phase": "Running",
-					"containerStatuses": []interface{}{
-						map[string]interface{}{"state": "unexpected-string"},
+					"containerStatuses": []any{
+						map[string]any{"state": "unexpected-string"},
 					},
 				},
 			},
@@ -437,11 +436,11 @@ func TestPodStatus(t *testing.T) {
 		},
 		{
 			name: "empty state object falls back to phase",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
+			obj: map[string]any{
+				"status": map[string]any{
 					"phase": "Running",
-					"containerStatuses": []interface{}{
-						map[string]interface{}{"state": map[string]interface{}{}},
+					"containerStatuses": []any{
+						map[string]any{"state": map[string]any{}},
 					},
 				},
 			},
@@ -462,17 +461,17 @@ func TestPodStatus(t *testing.T) {
 func TestPodReady(t *testing.T) {
 	tests := []struct {
 		name string
-		obj  map[string]interface{}
+		obj  map[string]any
 		want string
 	}{
 		{
 			name: "2 of 3 ready",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
-					"containerStatuses": []interface{}{
-						map[string]interface{}{"ready": true},
-						map[string]interface{}{"ready": true},
-						map[string]interface{}{"ready": false},
+			obj: map[string]any{
+				"status": map[string]any{
+					"containerStatuses": []any{
+						map[string]any{"ready": true},
+						map[string]any{"ready": true},
+						map[string]any{"ready": false},
 					},
 				},
 			},
@@ -480,16 +479,16 @@ func TestPodReady(t *testing.T) {
 		},
 		{
 			name: "no containers",
-			obj:  map[string]interface{}{},
+			obj:  map[string]any{},
 			want: "0/0",
 		},
 		{
 			name: "non-map entry skipped",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
-					"containerStatuses": []interface{}{
+			obj: map[string]any{
+				"status": map[string]any{
+					"containerStatuses": []any{
 						"not-a-map",
-						map[string]interface{}{"ready": true},
+						map[string]any{"ready": true},
 					},
 				},
 			},
@@ -510,16 +509,16 @@ func TestPodReady(t *testing.T) {
 func TestPodRestarts(t *testing.T) {
 	tests := []struct {
 		name string
-		obj  map[string]interface{}
+		obj  map[string]any
 		want string
 	}{
 		{
 			name: "int64 restart counts",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
-					"containerStatuses": []interface{}{
-						map[string]interface{}{"restartCount": int64(3)},
-						map[string]interface{}{"restartCount": int64(2)},
+			obj: map[string]any{
+				"status": map[string]any{
+					"containerStatuses": []any{
+						map[string]any{"restartCount": int64(3)},
+						map[string]any{"restartCount": int64(2)},
 					},
 				},
 			},
@@ -527,10 +526,10 @@ func TestPodRestarts(t *testing.T) {
 		},
 		{
 			name: "float64 restart counts",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
-					"containerStatuses": []interface{}{
-						map[string]interface{}{"restartCount": float64(7)},
+			obj: map[string]any{
+				"status": map[string]any{
+					"containerStatuses": []any{
+						map[string]any{"restartCount": float64(7)},
 					},
 				},
 			},
@@ -538,14 +537,14 @@ func TestPodRestarts(t *testing.T) {
 		},
 		{
 			name: "no containers",
-			obj:  map[string]interface{}{},
+			obj:  map[string]any{},
 			want: "0",
 		},
 		{
 			name: "non-map entry skipped",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
-					"containerStatuses": []interface{}{
+			obj: map[string]any{
+				"status": map[string]any{
+					"containerStatuses": []any{
 						"not-a-map",
 					},
 				},
@@ -554,10 +553,10 @@ func TestPodRestarts(t *testing.T) {
 		},
 		{
 			name: "unsupported type for restartCount",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
-					"containerStatuses": []interface{}{
-						map[string]interface{}{"restartCount": "not-a-number"},
+			obj: map[string]any{
+				"status": map[string]any{
+					"containerStatuses": []any{
+						map[string]any{"restartCount": "not-a-number"},
 					},
 				},
 			},
@@ -585,8 +584,8 @@ func TestResourceAge(t *testing.T) {
 	})
 
 	t.Run("zero timestamp", func(t *testing.T) {
-		u := unstructured.Unstructured{Object: map[string]interface{}{
-			"metadata": map[string]interface{}{"name": "x"},
+		u := unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "x"},
 		}}
 		got := resourceAge(u)
 		if got != "<unknown>" {
@@ -596,8 +595,8 @@ func TestResourceAge(t *testing.T) {
 }
 
 func TestGetStrField(t *testing.T) {
-	obj := map[string]interface{}{
-		"spec": map[string]interface{}{
+	obj := map[string]any{
+		"spec": map[string]any{
 			"nodeName": "node-1",
 		},
 		"intVal": int64(42),
@@ -626,8 +625,8 @@ func TestGetStrField(t *testing.T) {
 }
 
 func TestGetIntField(t *testing.T) {
-	obj := map[string]interface{}{
-		"status": map[string]interface{}{
+	obj := map[string]any{
+		"status": map[string]any{
 			"readyReplicas": int64(3),
 			"floatVal":      float64(7),
 			"strVal":        "nope",
@@ -660,16 +659,16 @@ func TestGetIntField(t *testing.T) {
 func TestConditionIsTrue(t *testing.T) {
 	tests := []struct {
 		name     string
-		obj      map[string]interface{}
+		obj      map[string]any
 		condType string
 		want     bool
 	}{
 		{
 			name: "condition True",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
-					"conditions": []interface{}{
-						map[string]interface{}{"type": "Ready", "status": "True"},
+			obj: map[string]any{
+				"status": map[string]any{
+					"conditions": []any{
+						map[string]any{"type": "Ready", "status": "True"},
 					},
 				},
 			},
@@ -678,10 +677,10 @@ func TestConditionIsTrue(t *testing.T) {
 		},
 		{
 			name: "condition False",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
-					"conditions": []interface{}{
-						map[string]interface{}{"type": "Ready", "status": "False"},
+			obj: map[string]any{
+				"status": map[string]any{
+					"conditions": []any{
+						map[string]any{"type": "Ready", "status": "False"},
 					},
 				},
 			},
@@ -690,9 +689,9 @@ func TestConditionIsTrue(t *testing.T) {
 		},
 		{
 			name: "condition missing",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
-					"conditions": []interface{}{},
+			obj: map[string]any{
+				"status": map[string]any{
+					"conditions": []any{},
 				},
 			},
 			condType: "Ready",
@@ -700,9 +699,9 @@ func TestConditionIsTrue(t *testing.T) {
 		},
 		{
 			name: "non-map condition entry skipped",
-			obj: map[string]interface{}{
-				"status": map[string]interface{}{
-					"conditions": []interface{}{"not-a-map"},
+			obj: map[string]any{
+				"status": map[string]any{
+					"conditions": []any{"not-a-map"},
 				},
 			},
 			condType: "Ready",
@@ -710,7 +709,7 @@ func TestConditionIsTrue(t *testing.T) {
 		},
 		{
 			name:     "no conditions field",
-			obj:      map[string]interface{}{},
+			obj:      map[string]any{},
 			condType: "Ready",
 			want:     false,
 		},
@@ -729,35 +728,35 @@ func TestConditionIsTrue(t *testing.T) {
 func TestNestedSlice(t *testing.T) {
 	tests := []struct {
 		name      string
-		obj       map[string]interface{}
+		obj       map[string]any
 		keys      []string
 		wantLen   int
 		wantFound bool
 	}{
 		{
 			name:      "valid path",
-			obj:       map[string]interface{}{"a": map[string]interface{}{"b": []interface{}{1, 2}}},
+			obj:       map[string]any{"a": map[string]any{"b": []any{1, 2}}},
 			keys:      []string{"a", "b"},
 			wantLen:   2,
 			wantFound: true,
 		},
 		{
 			name:      "missing field",
-			obj:       map[string]interface{}{},
+			obj:       map[string]any{},
 			keys:      []string{"a", "b"},
 			wantLen:   0,
 			wantFound: false,
 		},
 		{
 			name:      "wrong type at leaf",
-			obj:       map[string]interface{}{"a": map[string]interface{}{"b": "not-a-slice"}},
+			obj:       map[string]any{"a": map[string]any{"b": "not-a-slice"}},
 			keys:      []string{"a", "b"},
 			wantLen:   0,
 			wantFound: false,
 		},
 		{
 			name:      "non-map intermediate",
-			obj:       map[string]interface{}{"a": "string"},
+			obj:       map[string]any{"a": "string"},
 			keys:      []string{"a", "b"},
 			wantLen:   0,
 			wantFound: false,
@@ -834,11 +833,11 @@ func TestNodeRoles(t *testing.T) {
 }
 
 func TestEnrichDeployment_PartiallyAvailable(t *testing.T) {
-	obj := map[string]interface{}{
-		"spec":   map[string]interface{}{"replicas": int64(3)},
-		"status": map[string]interface{}{"readyReplicas": int64(1), "updatedReplicas": int64(2), "availableReplicas": int64(1)},
+	obj := map[string]any{
+		"spec":   map[string]any{"replicas": int64(3)},
+		"status": map[string]any{"readyReplicas": int64(1), "updatedReplicas": int64(2), "availableReplicas": int64(1)},
 	}
-	s := map[string]interface{}{}
+	s := map[string]any{}
 	enrichDeployment(s, obj)
 	if s["ready"] != "1/3" {
 		t.Errorf("expected 1/3, got %v", s["ready"])
@@ -852,11 +851,11 @@ func TestEnrichDeployment_PartiallyAvailable(t *testing.T) {
 }
 
 func TestEnrichStatefulSet(t *testing.T) {
-	obj := map[string]interface{}{
-		"spec":   map[string]interface{}{"replicas": int64(5)},
-		"status": map[string]interface{}{"readyReplicas": int64(5)},
+	obj := map[string]any{
+		"spec":   map[string]any{"replicas": int64(5)},
+		"status": map[string]any{"readyReplicas": int64(5)},
 	}
-	s := map[string]interface{}{}
+	s := map[string]any{}
 	enrichStatefulSet(s, obj)
 	if s["ready"] != "5/5" {
 		t.Errorf("expected 5/5, got %v", s["ready"])
@@ -864,14 +863,14 @@ func TestEnrichStatefulSet(t *testing.T) {
 }
 
 func TestEnrichDaemonSet(t *testing.T) {
-	obj := map[string]interface{}{
-		"status": map[string]interface{}{
+	obj := map[string]any{
+		"status": map[string]any{
 			"desiredNumberScheduled": int64(3),
 			"numberReady":            int64(3),
 			"numberAvailable":        int64(3),
 		},
 	}
-	s := map[string]interface{}{}
+	s := map[string]any{}
 	enrichDaemonSet(s, obj)
 	if s["desired"] != int64(3) {
 		t.Errorf("expected desired 3, got %v", s["desired"])

--- a/internal/tools/get_format.go
+++ b/internal/tools/get_format.go
@@ -67,7 +67,7 @@ func formatGetSummary(obj *unstructured.Unstructured) (*mcp.CallToolResult, erro
 }
 
 // enrichGeneric adds basic fields for unknown resource kinds.
-func enrichGeneric(s map[string]interface{}, obj *unstructured.Unstructured) {
+func enrichGeneric(s map[string]any, obj *unstructured.Unstructured) {
 	s["kind"] = obj.GetKind()
 	s["apiVersion"] = obj.GetAPIVersion()
 	if labels := obj.GetLabels(); len(labels) > 0 {

--- a/internal/tools/get_format_test.go
+++ b/internal/tools/get_format_test.go
@@ -12,28 +12,28 @@ import (
 )
 
 func TestGetResourceFormatParameter(t *testing.T) {
-	pod := &unstructured.Unstructured{Object: map[string]interface{}{
+	pod := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Pod",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              "fmt-pod",
 			"namespace":         "default",
 			"creationTimestamp": "2024-01-01T00:00:00Z",
 			"uid":               "uid-abc",
 			"resourceVersion":   "42",
-			"managedFields":     []interface{}{map[string]interface{}{"manager": "kubectl"}},
+			"managedFields":     []any{map[string]any{"manager": "kubectl"}},
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"nodeName": "node-1",
 		},
-		"status": map[string]interface{}{
+		"status": map[string]any{
 			"phase": "Running",
-			"containerStatuses": []interface{}{
-				map[string]interface{}{
+			"containerStatuses": []any{
+				map[string]any{
 					"ready":        true,
 					"restartCount": int64(0),
-					"state": map[string]interface{}{
-						"running": map[string]interface{}{
+					"state": map[string]any{
+						"running": map[string]any{
 							"startedAt": "2024-01-01T00:00:00Z",
 						},
 					},
@@ -194,13 +194,13 @@ func TestGetResourceFormatParameter(t *testing.T) {
 
 func TestGetResourceSummaryGenericKind(t *testing.T) {
 	// Test summary format for an unknown kind (not Pod, Deployment, etc.)
-	ns := &unstructured.Unstructured{Object: map[string]interface{}{
+	ns := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Namespace",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              "test-ns",
 			"creationTimestamp": "2024-01-01T00:00:00Z",
-			"labels":            map[string]interface{}{"env": "test"},
+			"labels":            map[string]any{"env": "test"},
 		},
 	}}
 
@@ -240,12 +240,12 @@ func TestGetResourceSummaryGenericKind(t *testing.T) {
 }
 
 func TestEnrichGeneric(t *testing.T) {
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+	obj := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "ConfigMap",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name": "test-cm",
-			"labels": map[string]interface{}{
+			"labels": map[string]any{
 				"app": "web",
 			},
 		},
@@ -270,10 +270,10 @@ func TestEnrichGeneric(t *testing.T) {
 }
 
 func TestEnrichGenericNoLabels(t *testing.T) {
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+	obj := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "ConfigMap",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name": "test-cm",
 		},
 	}}

--- a/internal/tools/handlers_test.go
+++ b/internal/tools/handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 
@@ -136,21 +137,21 @@ func newFakeDynClient(objs ...runtime.Object) *fakedynamic.FakeDynamicClient {
 
 // testPod returns an unstructured Pod object.
 func testPod(name, ns string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Pod",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              name,
 			"namespace":         ns,
 			"creationTimestamp": "2024-01-01T00:00:00Z",
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"nodeName": "node-1",
 		},
-		"status": map[string]interface{}{
+		"status": map[string]any{
 			"phase": "Running",
-			"conditions": []interface{}{
-				map[string]interface{}{
+			"conditions": []any{
+				map[string]any{
 					"type":    "Ready",
 					"status":  "True",
 					"reason":  "PodReady",
@@ -163,15 +164,15 @@ func testPod(name, ns string) *unstructured.Unstructured {
 
 // testSecret returns an unstructured Secret object.
 func testSecret(name, ns string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Secret",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              name,
 			"namespace":         ns,
 			"creationTimestamp": "2024-01-01T00:00:00Z",
 		},
-		"data": map[string]interface{}{
+		"data": map[string]any{
 			"password": "c2VjcmV0",
 		},
 	}}
@@ -179,10 +180,10 @@ func testSecret(name, ns string) *unstructured.Unstructured {
 
 // testNode returns an unstructured Node object (cluster-scoped).
 func testNode(name string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Node",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              name,
 			"creationTimestamp": "2024-01-01T00:00:00Z",
 		},
@@ -191,18 +192,18 @@ func testNode(name string) *unstructured.Unstructured {
 
 // testDeployment returns an unstructured Deployment object.
 func testDeployment(name, ns string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "apps/v1",
 		"kind":       "Deployment",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              name,
 			"namespace":         ns,
 			"creationTimestamp": "2024-01-01T00:00:00Z",
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"replicas": int64(3),
 		},
-		"status": map[string]interface{}{
+		"status": map[string]any{
 			"readyReplicas":     int64(3),
 			"updatedReplicas":   int64(3),
 			"availableReplicas": int64(3),
@@ -560,7 +561,7 @@ func TestListAPIResourcesHandler(t *testing.T) {
 		if res.StructuredContent == nil {
 			t.Fatal("expected StructuredContent to be populated for JSON format")
 		}
-		envelope, ok := res.StructuredContent.(map[string]interface{})
+		envelope, ok := res.StructuredContent.(map[string]any)
 		if !ok {
 			t.Fatalf("expected map[string]interface{}, got %T", res.StructuredContent)
 		}
@@ -675,13 +676,7 @@ func TestListAPIResourcesHandler(t *testing.T) {
 			t.Fatal(err)
 		}
 		for _, e := range entries {
-			hasVerb := false
-			for _, v := range e.Verbs {
-				if v == "list" {
-					hasVerb = true
-					break
-				}
-			}
+			hasVerb := slices.Contains(e.Verbs, "list")
 			if !hasVerb {
 				t.Errorf("expected %s to have 'list' verb", e.Kind)
 			}
@@ -873,16 +868,16 @@ func TestListResourcesHandler(t *testing.T) {
 	pod1 := testPod("pod-a", "default")
 	pod2 := testPod("pod-b", "default")
 	// Pod with Pending status.
-	pod3 := &unstructured.Unstructured{Object: map[string]interface{}{
+	pod3 := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Pod",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              "pod-c",
 			"namespace":         "other",
 			"creationTimestamp": "2024-01-01T00:00:00Z",
-			"labels":            map[string]interface{}{"app": "web"},
+			"labels":            map[string]any{"app": "web"},
 		},
-		"status": map[string]interface{}{"phase": "Pending"},
+		"status": map[string]any{"phase": "Pending"},
 	}}
 
 	cfg := defaultCfg()
@@ -1137,18 +1132,18 @@ func TestListResourcesFormatParameter(t *testing.T) {
 	})
 
 	t.Run("format=json returns full objects with metadata stripped", func(t *testing.T) {
-		podWithMeta := &unstructured.Unstructured{Object: map[string]interface{}{
+		podWithMeta := &unstructured.Unstructured{Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "Pod",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":              "json-pod",
 				"namespace":         "default",
 				"creationTimestamp": "2024-01-01T00:00:00Z",
 				"uid":               "uid-123",
 				"resourceVersion":   "99",
-				"managedFields":     []interface{}{map[string]interface{}{"manager": "x"}},
+				"managedFields":     []any{map[string]any{"manager": "x"}},
 			},
-			"spec": map[string]interface{}{"nodeName": "node-1"},
+			"spec": map[string]any{"nodeName": "node-1"},
 		}}
 		dynClient2 := newFakeDynClient(podWithMeta)
 		pool2 := buildPool(cfg, defaultRawConfig(), dynClient2, fake.NewClientset())
@@ -1281,15 +1276,15 @@ func TestDescribeResourceHandler(t *testing.T) {
 	})
 
 	t.Run("describe with labels and annotations", func(t *testing.T) {
-		labeled := &unstructured.Unstructured{Object: map[string]interface{}{
+		labeled := &unstructured.Unstructured{Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "Pod",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":              "labeled-pod",
 				"namespace":         "default",
 				"creationTimestamp": "2024-01-01T00:00:00Z",
-				"labels":            map[string]interface{}{"app": "web"},
-				"annotations":       map[string]interface{}{"note": "test"},
+				"labels":            map[string]any{"app": "web"},
+				"annotations":       map[string]any{"note": "test"},
 			},
 		}}
 		dynClient3 := newFakeDynClient(labeled)
@@ -1339,21 +1334,21 @@ func TestDescribeResourceHandler(t *testing.T) {
 	})
 
 	t.Run("managedFields stripped from describe output", func(t *testing.T) {
-		podWithMF := &unstructured.Unstructured{Object: map[string]interface{}{
+		podWithMF := &unstructured.Unstructured{Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "Pod",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":              "mf-pod",
 				"namespace":         "default",
 				"creationTimestamp": "2024-01-01T00:00:00Z",
-				"managedFields": []interface{}{
-					map[string]interface{}{
+				"managedFields": []any{
+					map[string]any{
 						"manager":   "kubectl",
 						"operation": "Apply",
 					},
 				},
 			},
-			"spec": map[string]interface{}{"nodeName": "node-1"},
+			"spec": map[string]any{"nodeName": "node-1"},
 		}}
 		dynMF := newFakeDynClient(podWithMF)
 		poolMF := buildPool(cfg, defaultRawConfig(), dynMF, fake.NewClientset())

--- a/internal/tools/helpers.go
+++ b/internal/tools/helpers.go
@@ -70,8 +70,8 @@ func parseDuration(s string) (time.Duration, error) {
 	}
 
 	// Handle "d" suffix for days (not supported by time.ParseDuration).
-	if strings.HasSuffix(s, "d") {
-		days, err := strconv.Atoi(strings.TrimSuffix(s, "d"))
+	if before, ok := strings.CutSuffix(s, "d"); ok {
+		days, err := strconv.Atoi(before)
 		if err != nil {
 			return 0, fmt.Errorf("invalid duration %q: %w", s, err)
 		}

--- a/internal/tools/list.go
+++ b/internal/tools/list.go
@@ -211,7 +211,7 @@ func parseFilters(raw string) ([]filterExpr, error) {
 	}
 
 	var filters []filterExpr
-	for _, part := range strings.Split(raw, ",") {
+	for part := range strings.SplitSeq(raw, ",") {
 		part = strings.TrimSpace(part)
 		if part == "" {
 			continue
@@ -255,7 +255,7 @@ func applyFilters(items []unstructured.Unstructured, filters []filterExpr) []uns
 	return result
 }
 
-func matchesAllFilters(obj map[string]interface{}, filters []filterExpr) bool {
+func matchesAllFilters(obj map[string]any, filters []filterExpr) bool {
 	for _, f := range filters {
 		actual, found := nestedFieldValue(obj, f.path)
 		if !found {
@@ -276,17 +276,17 @@ func matchesAllFilters(obj map[string]interface{}, filters []filterExpr) bool {
 
 // nestedFieldValue traverses the object using the dot-path and returns
 // the value as a string plus whether the field was found.
-func nestedFieldValue(obj interface{}, path []string) (string, bool) {
+func nestedFieldValue(obj any, path []string) (string, bool) {
 	current := obj
 	for _, key := range path {
 		switch v := current.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			val, ok := v[key]
 			if !ok {
 				return "", false
 			}
 			current = val
-		case []interface{}:
+		case []any:
 			idx := 0
 			for _, c := range key {
 				if c < '0' || c > '9' {

--- a/internal/tools/list_filter_test.go
+++ b/internal/tools/list_filter_test.go
@@ -52,13 +52,13 @@ func TestParseFilters(t *testing.T) {
 
 func TestApplyFilters(t *testing.T) {
 	items := []unstructured.Unstructured{
-		{Object: map[string]interface{}{
-			"metadata": map[string]interface{}{"name": "pod1"},
-			"status":   map[string]interface{}{"phase": "Running"},
+		{Object: map[string]any{
+			"metadata": map[string]any{"name": "pod1"},
+			"status":   map[string]any{"phase": "Running"},
 		}},
-		{Object: map[string]interface{}{
-			"metadata": map[string]interface{}{"name": "pod2"},
-			"status":   map[string]interface{}{"phase": "Pending"},
+		{Object: map[string]any{
+			"metadata": map[string]any{"name": "pod2"},
+			"status":   map[string]any{"phase": "Pending"},
 		}},
 	}
 
@@ -75,7 +75,7 @@ func TestApplyFilters(t *testing.T) {
 		if len(got) != 1 {
 			t.Fatalf("expected 1 item, got %d", len(got))
 		}
-		if got[0].Object["metadata"].(map[string]interface{})["name"] != "pod1" {
+		if got[0].Object["metadata"].(map[string]any)["name"] != "pod1" {
 			t.Error("expected pod1 to match")
 		}
 	})
@@ -90,9 +90,9 @@ func TestApplyFilters(t *testing.T) {
 }
 
 func TestMatchesAllFilters(t *testing.T) {
-	obj := map[string]interface{}{
-		"status": map[string]interface{}{"phase": "Running"},
-		"spec":   map[string]interface{}{"nodeName": "node-1"},
+	obj := map[string]any{
+		"status": map[string]any{"phase": "Running"},
+		"spec":   map[string]any{"nodeName": "node-1"},
 	}
 
 	tests := []struct {
@@ -162,12 +162,12 @@ func TestMatchesAllFilters(t *testing.T) {
 }
 
 func TestNestedFieldValue(t *testing.T) {
-	obj := map[string]interface{}{
-		"status": map[string]interface{}{
+	obj := map[string]any{
+		"status": map[string]any{
 			"phase": "Running",
-			"containerStatuses": []interface{}{
-				map[string]interface{}{"ready": true},
-				map[string]interface{}{"ready": false},
+			"containerStatuses": []any{
+				map[string]any{"ready": true},
+				map[string]any{"ready": false},
 			},
 		},
 		"notAMap": "string",

--- a/internal/tools/list_format.go
+++ b/internal/tools/list_format.go
@@ -20,8 +20,8 @@ const tableAcceptHeader = "application/json;as=Table;g=meta.k8s.io;v=v1"
 
 // wrapListEnvelope wraps a list of items in an object envelope for structuredContent.
 // The MCP protocol requires structuredContent to be a JSON object, not an array.
-func wrapListEnvelope(items []map[string]interface{}, continueToken string) map[string]interface{} {
-	envelope := map[string]interface{}{
+func wrapListEnvelope(items []map[string]any, continueToken string) map[string]any {
+	envelope := map[string]any{
 		"items": items,
 		"count": len(items),
 	}
@@ -32,8 +32,8 @@ func wrapListEnvelope(items []map[string]interface{}, continueToken string) map[
 }
 
 // formatListAsJSON strips noisy metadata from each item and returns a JSON array.
-func formatListAsJSON(items []unstructured.Unstructured) (string, []map[string]interface{}, error) {
-	cleaned := make([]map[string]interface{}, 0, len(items))
+func formatListAsJSON(items []unstructured.Unstructured) (string, []map[string]any, error) {
+	cleaned := make([]map[string]any, 0, len(items))
 	for _, item := range items {
 		cleaned = append(cleaned, StripNoisyMetadata(item.Object))
 	}

--- a/internal/tools/list_format_test.go
+++ b/internal/tools/list_format_test.go
@@ -18,8 +18,8 @@ func TestFormatTable(t *testing.T) {
 				{Name: "Age"},
 			},
 			Rows: []metav1.TableRow{
-				{Cells: []interface{}{"pod-a", "Running", "5d"}},
-				{Cells: []interface{}{"pod-b", "Pending", "2h"}},
+				{Cells: []any{"pod-a", "Running", "5d"}},
+				{Cells: []any{"pod-b", "Pending", "2h"}},
 			},
 		}
 
@@ -70,8 +70,8 @@ func TestFormatTable(t *testing.T) {
 				{Name: "Ready"},
 			},
 			Rows: []metav1.TableRow{
-				{Cells: []interface{}{"short", "1/1"}},
-				{Cells: []interface{}{"a-very-long-name", "2/2"}},
+				{Cells: []any{"short", "1/1"}},
+				{Cells: []any{"a-very-long-name", "2/2"}},
 			},
 		}
 
@@ -94,7 +94,7 @@ func TestFormatTable(t *testing.T) {
 				{Name: "Status"},
 			},
 			Rows: []metav1.TableRow{
-				{Cells: []interface{}{"only-name"}},
+				{Cells: []any{"only-name"}},
 			},
 		}
 
@@ -107,21 +107,21 @@ func TestFormatTable(t *testing.T) {
 
 func TestFormatListAsJSON(t *testing.T) {
 	items := []unstructured.Unstructured{
-		{Object: map[string]interface{}{
+		{Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "Pod",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":            "pod-a",
 				"namespace":       "default",
 				"uid":             "abc-123",
 				"resourceVersion": "100",
-				"managedFields":   []interface{}{},
+				"managedFields":   []any{},
 			},
 		}},
-		{Object: map[string]interface{}{
+		{Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "Pod",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "pod-b",
 				"namespace": "default",
 				"uid":       "def-456",
@@ -153,7 +153,7 @@ func TestFormatListAsJSON(t *testing.T) {
 	}
 
 	// Verify original items are not mutated.
-	meta := items[0].Object["metadata"].(map[string]interface{})
+	meta := items[0].Object["metadata"].(map[string]any)
 	if _, ok := meta["uid"]; !ok {
 		t.Error("original item uid should not be removed (immutability violated)")
 	}
@@ -161,14 +161,14 @@ func TestFormatListAsJSON(t *testing.T) {
 
 func TestHandleListFormatStructuredContentIsObject(t *testing.T) {
 	items := []unstructured.Unstructured{
-		{Object: map[string]interface{}{
+		{Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "Pod",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "pod-a",
 				"namespace": "default",
 			},
-			"status": map[string]interface{}{"phase": "Running"},
+			"status": map[string]any{"phase": "Running"},
 		}},
 	}
 
@@ -189,7 +189,7 @@ func TestHandleListFormatStructuredContentIsObject(t *testing.T) {
 			}
 
 			// Must be a map (JSON object), not a slice.
-			envelope, ok := result.StructuredContent.(map[string]interface{})
+			envelope, ok := result.StructuredContent.(map[string]any)
 			if !ok {
 				t.Fatalf("expected map[string]interface{}, got %T", result.StructuredContent)
 			}
@@ -205,33 +205,33 @@ func TestHandleListFormatStructuredContentIsObject(t *testing.T) {
 
 func TestHandleListFormat_SummaryStructuredContentIsCompact(t *testing.T) {
 	items := []unstructured.Unstructured{
-		{Object: map[string]interface{}{
+		{Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "Pod",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":              "pod-a",
 				"namespace":         "default",
 				"creationTimestamp": "2024-01-01T00:00:00Z",
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"nodeName": "node-1",
-				"containers": []interface{}{
-					map[string]interface{}{
+				"containers": []any{
+					map[string]any{
 						"name":  "nginx",
 						"image": "nginx:latest",
-						"ports": []interface{}{
-							map[string]interface{}{"containerPort": int64(80)},
+						"ports": []any{
+							map[string]any{"containerPort": int64(80)},
 						},
 					},
 				},
 			},
-			"status": map[string]interface{}{
+			"status": map[string]any{
 				"phase": "Running",
-				"containerStatuses": []interface{}{
-					map[string]interface{}{
+				"containerStatuses": []any{
+					map[string]any{
 						"ready":        true,
 						"restartCount": int64(2),
-						"state":        map[string]interface{}{},
+						"state":        map[string]any{},
 					},
 				},
 			},
@@ -249,11 +249,11 @@ func TestHandleListFormat_SummaryStructuredContentIsCompact(t *testing.T) {
 		t.Fatal("unexpected error result")
 	}
 
-	envelope, ok := result.StructuredContent.(map[string]interface{})
+	envelope, ok := result.StructuredContent.(map[string]any)
 	if !ok {
 		t.Fatalf("expected map envelope, got %T", result.StructuredContent)
 	}
-	structItems, ok := envelope["items"].([]map[string]interface{})
+	structItems, ok := envelope["items"].([]map[string]any)
 	if !ok {
 		t.Fatalf("expected items to be []map[string]interface{}, got %T", envelope["items"])
 	}
@@ -271,7 +271,7 @@ func TestHandleListFormat_SummaryStructuredContentIsCompact(t *testing.T) {
 		t.Error("summary structuredContent item should NOT have 'kind'")
 	}
 	if statusVal, hasStatus := item["status"]; hasStatus {
-		if _, isMap := statusVal.(map[string]interface{}); isMap {
+		if _, isMap := statusVal.(map[string]any); isMap {
 			t.Error("summary structuredContent 'status' should be a string, not a nested object")
 		}
 	}

--- a/internal/tools/list_sort.go
+++ b/internal/tools/list_sort.go
@@ -27,7 +27,7 @@ func parseSortBy(raw string) (fieldPath string, descending bool) {
 // For RFC3339 timestamps it returns a zero-padded representation so that
 // lexicographic ordering equals chronological ordering.
 // Returns ("", false) when the field is absent.
-func extractSortKey(obj map[string]interface{}, fieldPath string) (string, bool) {
+func extractSortKey(obj map[string]any, fieldPath string) (string, bool) {
 	parts := strings.Split(fieldPath, ".")
 	raw, found := nestedFieldValue(obj, parts)
 	if !found {

--- a/internal/tools/list_sort_test.go
+++ b/internal/tools/list_sort_test.go
@@ -16,8 +16,8 @@ import (
 
 func TestSortUnstructured(t *testing.T) {
 	makeItem := func(name string) unstructured.Unstructured {
-		return unstructured.Unstructured{Object: map[string]interface{}{
-			"metadata": map[string]interface{}{"name": name},
+		return unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": name},
 		}}
 	}
 
@@ -80,8 +80,8 @@ func TestSortUnstructured(t *testing.T) {
 
 func TestSortUnstructuredByTimestamp(t *testing.T) {
 	makeItemWithTS := func(name, ts string) unstructured.Unstructured {
-		return unstructured.Unstructured{Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
+		return unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
 				"name":              name,
 				"creationTimestamp": ts,
 			},
@@ -124,35 +124,35 @@ func TestSortUnstructuredByTimestamp(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestListResourcesSortBy(t *testing.T) {
-	pod1 := &unstructured.Unstructured{Object: map[string]interface{}{
+	pod1 := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Pod",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              "pod-charlie",
 			"namespace":         "default",
 			"creationTimestamp": "2024-03-01T00:00:00Z",
 		},
-		"status": map[string]interface{}{"phase": "Running"},
+		"status": map[string]any{"phase": "Running"},
 	}}
-	pod2 := &unstructured.Unstructured{Object: map[string]interface{}{
+	pod2 := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Pod",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              "pod-alpha",
 			"namespace":         "default",
 			"creationTimestamp": "2024-01-01T00:00:00Z",
 		},
-		"status": map[string]interface{}{"phase": "Running"},
+		"status": map[string]any{"phase": "Running"},
 	}}
-	pod3 := &unstructured.Unstructured{Object: map[string]interface{}{
+	pod3 := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Pod",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              "pod-bravo",
 			"namespace":         "default",
 			"creationTimestamp": "2024-02-01T00:00:00Z",
 		},
-		"status": map[string]interface{}{"phase": "Running"},
+		"status": map[string]any{"phase": "Running"},
 	}}
 
 	cfg := defaultCfg()

--- a/internal/tools/logs.go
+++ b/internal/tools/logs.go
@@ -198,7 +198,7 @@ func registerGetLogs(s *server.MCPServer, pool *kube.ClientPool) {
 			}
 			text := extractText(podRes)
 			// Prefix each line with pod name.
-			for _, line := range strings.Split(text, "\n") {
+			for line := range strings.SplitSeq(text, "\n") {
 				if line == "" {
 					continue
 				}

--- a/internal/tools/logs_resolve.go
+++ b/internal/tools/logs_resolve.go
@@ -105,17 +105,17 @@ func resolveCronJobToLabelSelector(ctx context.Context, cc *kube.ContextClient, 
 // extractMatchLabels extracts spec.selector.matchLabels from an unstructured
 // resource and returns them as a comma-separated label selector string.
 func extractMatchLabels(kind, name string, obj *unstructured.Unstructured) (string, error) {
-	spec, ok := obj.Object["spec"].(map[string]interface{})
+	spec, ok := obj.Object["spec"].(map[string]any)
 	if !ok {
 		return "", fmt.Errorf("%s/%s has no spec", kind, name)
 	}
 
-	selector, ok := spec["selector"].(map[string]interface{})
+	selector, ok := spec["selector"].(map[string]any)
 	if !ok {
 		return "", fmt.Errorf("%s/%s has no spec.selector", kind, name)
 	}
 
-	matchLabels, ok := selector["matchLabels"].(map[string]interface{})
+	matchLabels, ok := selector["matchLabels"].(map[string]any)
 	if !ok || len(matchLabels) == 0 {
 		return "", fmt.Errorf("%s/%s has no spec.selector.matchLabels", kind, name)
 	}

--- a/internal/tools/logs_resolve_test.go
+++ b/internal/tools/logs_resolve_test.go
@@ -59,17 +59,17 @@ func TestResolveResourceToLabelSelector_Deployment(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.AllowWrite = true
 
-	dep := &unstructured.Unstructured{Object: map[string]interface{}{
+	dep := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "apps/v1",
 		"kind":       "Deployment",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              "my-deploy",
 			"namespace":         "default",
 			"creationTimestamp": "2024-01-01T00:00:00Z",
 		},
-		"spec": map[string]interface{}{
-			"selector": map[string]interface{}{
-				"matchLabels": map[string]interface{}{
+		"spec": map[string]any{
+			"selector": map[string]any{
+				"matchLabels": map[string]any{
 					"app": "nginx",
 				},
 			},
@@ -118,30 +118,30 @@ func TestResolveResourceToLabelSelector_CronJob(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.AllowWrite = true
 
-	cronJob := &unstructured.Unstructured{Object: map[string]interface{}{
+	cronJob := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "batch/v1",
 		"kind":       "CronJob",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              "my-cronjob",
 			"namespace":         "default",
 			"uid":               "cj-uid-123",
 			"creationTimestamp": "2024-01-01T00:00:00Z",
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"schedule": "*/5 * * * *",
 		},
 	}}
 
 	// Older Job owned by the CronJob.
-	oldJob := &unstructured.Unstructured{Object: map[string]interface{}{
+	oldJob := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "batch/v1",
 		"kind":       "Job",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              "my-cronjob-111",
 			"namespace":         "default",
 			"creationTimestamp": "2024-01-01T00:00:00Z",
-			"ownerReferences": []interface{}{
-				map[string]interface{}{
+			"ownerReferences": []any{
+				map[string]any{
 					"apiVersion": "batch/v1",
 					"kind":       "CronJob",
 					"name":       "my-cronjob",
@@ -149,9 +149,9 @@ func TestResolveResourceToLabelSelector_CronJob(t *testing.T) {
 				},
 			},
 		},
-		"spec": map[string]interface{}{
-			"selector": map[string]interface{}{
-				"matchLabels": map[string]interface{}{
+		"spec": map[string]any{
+			"selector": map[string]any{
+				"matchLabels": map[string]any{
 					"batch.kubernetes.io/controller-uid": "old-job-uid",
 				},
 			},
@@ -159,15 +159,15 @@ func TestResolveResourceToLabelSelector_CronJob(t *testing.T) {
 	}}
 
 	// Newer Job owned by the CronJob — should be selected.
-	newJob := &unstructured.Unstructured{Object: map[string]interface{}{
+	newJob := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "batch/v1",
 		"kind":       "Job",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              "my-cronjob-222",
 			"namespace":         "default",
 			"creationTimestamp": "2024-06-01T00:00:00Z",
-			"ownerReferences": []interface{}{
-				map[string]interface{}{
+			"ownerReferences": []any{
+				map[string]any{
 					"apiVersion": "batch/v1",
 					"kind":       "CronJob",
 					"name":       "my-cronjob",
@@ -175,9 +175,9 @@ func TestResolveResourceToLabelSelector_CronJob(t *testing.T) {
 				},
 			},
 		},
-		"spec": map[string]interface{}{
-			"selector": map[string]interface{}{
-				"matchLabels": map[string]interface{}{
+		"spec": map[string]any{
+			"selector": map[string]any{
+				"matchLabels": map[string]any{
 					"batch.kubernetes.io/controller-uid": "new-job-uid",
 				},
 			},
@@ -206,29 +206,29 @@ func TestResolveResourceToLabelSelector_CronJob_ShortName(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.AllowWrite = true
 
-	cronJob := &unstructured.Unstructured{Object: map[string]interface{}{
+	cronJob := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "batch/v1",
 		"kind":       "CronJob",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              "my-cj",
 			"namespace":         "default",
 			"uid":               "cj-uid-456",
 			"creationTimestamp": "2024-01-01T00:00:00Z",
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"schedule": "0 * * * *",
 		},
 	}}
 
-	job := &unstructured.Unstructured{Object: map[string]interface{}{
+	job := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "batch/v1",
 		"kind":       "Job",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              "my-cj-run1",
 			"namespace":         "default",
 			"creationTimestamp": "2024-01-01T01:00:00Z",
-			"ownerReferences": []interface{}{
-				map[string]interface{}{
+			"ownerReferences": []any{
+				map[string]any{
 					"apiVersion": "batch/v1",
 					"kind":       "CronJob",
 					"name":       "my-cj",
@@ -236,9 +236,9 @@ func TestResolveResourceToLabelSelector_CronJob_ShortName(t *testing.T) {
 				},
 			},
 		},
-		"spec": map[string]interface{}{
-			"selector": map[string]interface{}{
-				"matchLabels": map[string]interface{}{
+		"spec": map[string]any{
+			"selector": map[string]any{
+				"matchLabels": map[string]any{
 					"app": "worker",
 				},
 			},
@@ -268,16 +268,16 @@ func TestResolveResourceToLabelSelector_CronJob_NoJobs(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.AllowWrite = true
 
-	cronJob := &unstructured.Unstructured{Object: map[string]interface{}{
+	cronJob := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "batch/v1",
 		"kind":       "CronJob",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              "empty-cj",
 			"namespace":         "default",
 			"uid":               "cj-uid-789",
 			"creationTimestamp": "2024-01-01T00:00:00Z",
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"schedule": "0 0 * * *",
 		},
 	}}
@@ -374,16 +374,16 @@ func TestResolveCronJobToLabelSelector_ListJobsError(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.AllowWrite = true
 
-	cronJob := &unstructured.Unstructured{Object: map[string]interface{}{
+	cronJob := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "batch/v1",
 		"kind":       "CronJob",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              "fail-cj",
 			"namespace":         "default",
 			"uid":               "cj-uid-fail",
 			"creationTimestamp": "2024-01-01T00:00:00Z",
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"schedule": "0 0 * * *",
 		},
 	}}
@@ -413,10 +413,10 @@ func TestResolveCronJobToLabelSelector_ListJobsError(t *testing.T) {
 }
 
 func TestExtractMatchLabels_NoSpec(t *testing.T) {
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+	obj := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "apps/v1",
 		"kind":       "Deployment",
-		"metadata":   map[string]interface{}{"name": "test"},
+		"metadata":   map[string]any{"name": "test"},
 	}}
 
 	_, err := extractMatchLabels("Deployment", "test", obj)
@@ -429,11 +429,11 @@ func TestExtractMatchLabels_NoSpec(t *testing.T) {
 }
 
 func TestExtractMatchLabels_NoSelector(t *testing.T) {
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+	obj := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "apps/v1",
 		"kind":       "Deployment",
-		"metadata":   map[string]interface{}{"name": "test"},
-		"spec":       map[string]interface{}{"replicas": int64(1)},
+		"metadata":   map[string]any{"name": "test"},
+		"spec":       map[string]any{"replicas": int64(1)},
 	}}
 
 	_, err := extractMatchLabels("Deployment", "test", obj)
@@ -446,13 +446,13 @@ func TestExtractMatchLabels_NoSelector(t *testing.T) {
 }
 
 func TestExtractMatchLabels_NoMatchLabels(t *testing.T) {
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+	obj := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "apps/v1",
 		"kind":       "Deployment",
-		"metadata":   map[string]interface{}{"name": "test"},
-		"spec": map[string]interface{}{
-			"selector": map[string]interface{}{
-				"matchExpressions": []interface{}{},
+		"metadata":   map[string]any{"name": "test"},
+		"spec": map[string]any{
+			"selector": map[string]any{
+				"matchExpressions": []any{},
 			},
 		},
 	}}
@@ -467,13 +467,13 @@ func TestExtractMatchLabels_NoMatchLabels(t *testing.T) {
 }
 
 func TestExtractMatchLabels_EmptyMatchLabels(t *testing.T) {
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+	obj := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "apps/v1",
 		"kind":       "Deployment",
-		"metadata":   map[string]interface{}{"name": "test"},
-		"spec": map[string]interface{}{
-			"selector": map[string]interface{}{
-				"matchLabels": map[string]interface{}{},
+		"metadata":   map[string]any{"name": "test"},
+		"spec": map[string]any{
+			"selector": map[string]any{
+				"matchLabels": map[string]any{},
 			},
 		},
 	}}

--- a/internal/tools/logs_test.go
+++ b/internal/tools/logs_test.go
@@ -17,20 +17,20 @@ import (
 )
 
 // testRunningPod returns an unstructured Pod with the given labels and Running phase.
-func testRunningPod(name, ns string, labels map[string]interface{}) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+func testRunningPod(name, ns string, labels map[string]any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Pod",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              name,
 			"namespace":         ns,
 			"labels":            labels,
 			"creationTimestamp": "2024-01-01T00:00:00Z",
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"nodeName": "node-1",
 		},
-		"status": map[string]interface{}{
+		"status": map[string]any{
 			"phase": "Running",
 		},
 	}}
@@ -92,9 +92,9 @@ func TestGetLogs_LabelSelectorFindsPods(t *testing.T) {
 	cfg := defaultCfg()
 	fakeCS := fake.NewClientset()
 	dynClient := newFakeDynClient(
-		testRunningPod("nginx-1", "default", map[string]interface{}{"app": "nginx"}),
-		testRunningPod("nginx-2", "default", map[string]interface{}{"app": "nginx"}),
-		testRunningPod("redis-1", "default", map[string]interface{}{"app": "redis"}),
+		testRunningPod("nginx-1", "default", map[string]any{"app": "nginx"}),
+		testRunningPod("nginx-2", "default", map[string]any{"app": "nginx"}),
+		testRunningPod("redis-1", "default", map[string]any{"app": "redis"}),
 	)
 	pool := buildPool(cfg, defaultRawConfig(), dynClient, fakeCS)
 
@@ -371,7 +371,7 @@ func TestGetLogs_ReadFollowStream_BufferCapLines(t *testing.T) {
 	pr, pw := io.Pipe()
 	go func() {
 		defer func() { _ = pw.Close() }()
-		for i := 0; i < 10100; i++ {
+		for i := range 10100 {
 			_, _ = fmt.Fprintf(pw, "log line %d\n", i)
 		}
 	}()
@@ -392,7 +392,7 @@ func TestGetLogs_ReadFollowStream_BufferCapBytes(t *testing.T) {
 		defer func() { _ = pw.Close() }()
 		// Write lines that total > 1MB.
 		line := strings.Repeat("x", 1000) + "\n"
-		for i := 0; i < 1100; i++ {
+		for range 1100 {
 			_, _ = fmt.Fprint(pw, line)
 		}
 	}()

--- a/internal/tools/portforward.go
+++ b/internal/tools/portforward.go
@@ -91,9 +91,9 @@ var supportedKinds = []string{"Pod", "Service", "Deployment", "StatefulSet"}
 // (canonicalKind, name). Kind is lowercased and alias-expanded.
 // Unknown kinds are returned as-is (lowercased).
 func parseResource(resource string) (kind, name string) {
-	if idx := strings.IndexByte(resource, '/'); idx >= 0 {
-		rawKind := strings.ToLower(resource[:idx])
-		name = resource[idx+1:]
+	if before, after, ok := strings.Cut(resource, "/"); ok {
+		rawKind := strings.ToLower(before)
+		name = after
 		if canonical, ok := kindAliases[rawKind]; ok {
 			return canonical, name
 		}

--- a/internal/tools/portforward_test.go
+++ b/internal/tools/portforward_test.go
@@ -65,7 +65,7 @@ func TestPortForward_HappyPath(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}
@@ -111,7 +111,7 @@ func TestPortForward_WithLocalPort(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}
@@ -151,7 +151,7 @@ func TestPortForward_TimeoutClamped(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}
@@ -371,7 +371,7 @@ func TestPortForward_ResourceBareName(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}
@@ -408,7 +408,7 @@ func TestPortForward_ResourceExplicitPod(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}
@@ -477,7 +477,7 @@ func TestPortForward_ResourceService(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}
@@ -606,7 +606,7 @@ func TestPortForward_ResourceDeployment(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}
@@ -683,7 +683,7 @@ func TestPortForward_ResourceStatefulSet(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}

--- a/internal/tools/rbac.go
+++ b/internal/tools/rbac.go
@@ -53,11 +53,11 @@ func registerListRBACBindings(s *server.MCPServer, pool *kube.ClientPool) {
 		subjectKind := req.GetString("subjectKind", "")
 
 		type bindingItem struct {
-			Kind      string      `json:"kind"`
-			Name      string      `json:"name"`
-			Namespace string      `json:"namespace,omitempty"`
-			RoleRef   interface{} `json:"roleRef"`
-			Subjects  interface{} `json:"subjects"`
+			Kind      string `json:"kind"`
+			Name      string `json:"name"`
+			Namespace string `json:"namespace,omitempty"`
+			RoleRef   any    `json:"roleRef"`
+			Subjects  any    `json:"subjects"`
 		}
 
 		var items []bindingItem
@@ -110,7 +110,7 @@ func registerListRBACBindings(s *server.MCPServer, pool *kube.ClientPool) {
 }
 
 // subjectsMatch returns true if all non-empty filters match at least one subject.
-func subjectsMatch(subjects interface{}, name, kind string) bool {
+func subjectsMatch(subjects any, name, kind string) bool {
 	if name == "" && kind == "" {
 		return true
 	}
@@ -180,7 +180,7 @@ func registerListRBACRoles(s *server.MCPServer, pool *kube.ClientPool) {
 				if err != nil {
 					return mcp.NewToolResultError(fmt.Sprintf("role %q not found in namespace %q: %v", name, namespace, err)), nil
 				}
-				result := map[string]interface{}{
+				result := map[string]any{
 					"kind":      "Role",
 					"name":      role.Name,
 					"namespace": role.Namespace,
@@ -196,7 +196,7 @@ func registerListRBACRoles(s *server.MCPServer, pool *kube.ClientPool) {
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("cluster role %q not found: %v", name, err)), nil
 			}
-			result := map[string]interface{}{
+			result := map[string]any{
 				"kind":  "ClusterRole",
 				"name":  clusterRole.Name,
 				"rules": clusterRole.Rules,
@@ -292,7 +292,7 @@ func registerListServiceAccounts(s *server.MCPServer, pool *kube.ClientPool) {
 			for _, ref := range sa.Secrets {
 				secretNames = append(secretNames, ref.Name)
 			}
-			result := map[string]interface{}{
+			result := map[string]any{
 				"name":      sa.Name,
 				"namespace": sa.Namespace,
 				"secrets":   secretNames,

--- a/internal/tools/rbac_test.go
+++ b/internal/tools/rbac_test.go
@@ -51,7 +51,7 @@ func TestListRBACBindings_ClusterRoleBindings(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var items []map[string]interface{}
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(text), &items); err != nil {
 		t.Fatalf("expected JSON array, got: %s", text)
 	}
@@ -95,7 +95,7 @@ func TestListRBACBindings_RoleBindings(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := resultText(t, res)
-	var items []map[string]interface{}
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(text), &items); err != nil {
 		t.Fatalf("expected JSON array, got: %s", text)
 	}
@@ -136,7 +136,7 @@ func TestListRBACBindings_SubjectFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := resultText(t, res)
-	var items []map[string]interface{}
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(text), &items); err != nil {
 		t.Fatalf("expected JSON, got: %s", text)
 	}
@@ -174,7 +174,7 @@ func TestListRBACBindings_SubjectKindFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := resultText(t, res)
-	var items []map[string]interface{}
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(text), &items); err != nil {
 		t.Fatalf("expected JSON, got: %s", text)
 	}
@@ -251,7 +251,7 @@ func TestListRBACRoles_ClusterRoles(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := resultText(t, res)
-	var items []map[string]interface{}
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(text), &items); err != nil {
 		t.Fatalf("expected JSON array, got: %s", text)
 	}
@@ -288,7 +288,7 @@ func TestListRBACRoles_Roles(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := resultText(t, res)
-	var items []map[string]interface{}
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(text), &items); err != nil {
 		t.Fatalf("expected JSON, got: %s", text)
 	}
@@ -326,14 +326,14 @@ func TestListRBACRoles_NamedClusterRole(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON object, got: %s", text)
 	}
 	if result["name"] != "custom-role" {
 		t.Errorf("expected name=custom-role, got %v", result["name"])
 	}
-	rules, ok := result["rules"].([]interface{})
+	rules, ok := result["rules"].([]any)
 	if !ok || len(rules) == 0 {
 		t.Errorf("expected rules in detailed output, got: %v", result["rules"])
 	}
@@ -362,7 +362,7 @@ func TestListRBACRoles_NamedRole(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON object, got: %s", text)
 	}
@@ -440,7 +440,7 @@ func TestListServiceAccounts_List(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := resultText(t, res)
-	var items []map[string]interface{}
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(text), &items); err != nil {
 		t.Fatalf("expected JSON array, got: %s", text)
 	}
@@ -469,7 +469,7 @@ func TestListServiceAccounts_AllNamespaces(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := resultText(t, res)
-	var items []map[string]interface{}
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(text), &items); err != nil {
 		t.Fatalf("expected JSON array, got: %s", text)
 	}
@@ -504,7 +504,7 @@ func TestListServiceAccounts_Named(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON object, got: %s", text)
 	}
@@ -512,7 +512,7 @@ func TestListServiceAccounts_Named(t *testing.T) {
 		t.Errorf("expected name=my-sa, got %v", result["name"])
 	}
 	// Secret names should be visible, but not data.
-	secrets, ok := result["secrets"].([]interface{})
+	secrets, ok := result["secrets"].([]any)
 	if !ok || len(secrets) != 1 {
 		t.Errorf("expected 1 secret name, got: %v", result["secrets"])
 	}

--- a/internal/tools/register.go
+++ b/internal/tools/register.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/server"
@@ -139,10 +140,8 @@ func applyRequireContext(s *server.MCPServer) {
 }
 
 func appendUnique(ss []string, val string) []string {
-	for _, s := range ss {
-		if s == val {
-			return ss
-		}
+	if slices.Contains(ss, val) {
+		return ss
 	}
 	return append(ss, val)
 }

--- a/internal/tools/require_context_test.go
+++ b/internal/tools/require_context_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 
@@ -34,13 +35,7 @@ func TestApplyRequireContext_MarksContextRequired(t *testing.T) {
 		if !ok {
 			t.Fatalf("tool %q not registered", name)
 		}
-		found := false
-		for _, r := range st.Tool.InputSchema.Required {
-			if r == "context" {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(st.Tool.InputSchema.Required, "context")
 		if !found {
 			t.Errorf("tool %q should have context in Required, got %v", name, st.Tool.InputSchema.Required)
 		}

--- a/internal/tools/rollout_history.go
+++ b/internal/tools/rollout_history.go
@@ -32,9 +32,9 @@ type revisionSummary struct {
 
 // revisionDetail holds full detail for a single revision lookup.
 type revisionDetail struct {
-	Revision   int64                  `json:"revision"`
-	ReplicaSet string                 `json:"replicaSet"`
-	Template   map[string]interface{} `json:"template,omitempty"`
+	Revision   int64          `json:"revision"`
+	ReplicaSet string         `json:"replicaSet"`
+	Template   map[string]any `json:"template,omitempty"`
 }
 
 func registerRolloutHistory(s *server.MCPServer, pool *kube.ClientPool) {
@@ -120,12 +120,12 @@ func listOwnedReplicaSets(ctx context.Context, cc *kube.ContextClient, namespace
 // isOwnedBy checks whether the ReplicaSet has an ownerReference matching the
 // given Deployment name.
 func isOwnedBy(rs unstructured.Unstructured, ownerName string) bool {
-	refs, ok := rs.Object["metadata"].(map[string]interface{})["ownerReferences"].([]interface{})
+	refs, ok := rs.Object["metadata"].(map[string]any)["ownerReferences"].([]any)
 	if !ok {
 		return false
 	}
 	for _, ref := range refs {
-		m, ok := ref.(map[string]interface{})
+		m, ok := ref.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -157,7 +157,7 @@ func listRevisions(deployName string, rsList []unstructured.Unstructured) (*mcp.
 		return summaries[i].Revision < summaries[j].Revision
 	})
 
-	result := map[string]interface{}{
+	result := map[string]any{
 		"deployment": deployName,
 		"revisions":  summaries,
 	}
@@ -174,8 +174,8 @@ func lookupRevision(rsList []unstructured.Unstructured, targetRevision int64) (*
 	for _, rs := range rsList {
 		rev := extractRevision(rs)
 		if rev == targetRevision {
-			spec, _ := rs.Object["spec"].(map[string]interface{})
-			template, _ := spec["template"].(map[string]interface{})
+			spec, _ := rs.Object["spec"].(map[string]any)
+			template, _ := spec["template"].(map[string]any)
 
 			detail := revisionDetail{
 				Revision:   rev,
@@ -212,20 +212,20 @@ func extractRevision(rs unstructured.Unstructured) int64 {
 }
 
 // statusMap returns the status sub-object of an unstructured resource.
-func statusMap(obj unstructured.Unstructured) map[string]interface{} {
-	m, _ := obj.Object["status"].(map[string]interface{})
+func statusMap(obj unstructured.Unstructured) map[string]any {
+	m, _ := obj.Object["status"].(map[string]any)
 	return m
 }
 
 // firstContainerImage extracts the image from the first container in the pod template.
 func firstContainerImage(rs unstructured.Unstructured) string {
-	spec, _ := rs.Object["spec"].(map[string]interface{})
-	tmpl, _ := spec["template"].(map[string]interface{})
-	podSpec, _ := tmpl["spec"].(map[string]interface{})
-	containers, _ := podSpec["containers"].([]interface{})
+	spec, _ := rs.Object["spec"].(map[string]any)
+	tmpl, _ := spec["template"].(map[string]any)
+	podSpec, _ := tmpl["spec"].(map[string]any)
+	containers, _ := podSpec["containers"].([]any)
 	if len(containers) == 0 {
 		return ""
 	}
-	container, _ := containers[0].(map[string]interface{})
+	container, _ := containers[0].(map[string]any)
 	return toString(container, "image")
 }

--- a/internal/tools/rollout_history_test.go
+++ b/internal/tools/rollout_history_test.go
@@ -15,18 +15,18 @@ import (
 
 // testReplicaSet returns an unstructured ReplicaSet with revision annotation and owner reference.
 func testReplicaSet(name, ns, revision, ownerName string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "apps/v1",
 		"kind":       "ReplicaSet",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              name,
 			"namespace":         ns,
 			"creationTimestamp": "2024-01-01T00:00:00Z",
-			"annotations": map[string]interface{}{
+			"annotations": map[string]any{
 				"deployment.kubernetes.io/revision": revision,
 			},
-			"ownerReferences": []interface{}{
-				map[string]interface{}{
+			"ownerReferences": []any{
+				map[string]any{
 					"apiVersion": "apps/v1",
 					"kind":       "Deployment",
 					"name":       ownerName,
@@ -34,12 +34,12 @@ func testReplicaSet(name, ns, revision, ownerName string) *unstructured.Unstruct
 				},
 			},
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"replicas": int64(3),
-			"template": map[string]interface{}{
-				"spec": map[string]interface{}{
-					"containers": []interface{}{
-						map[string]interface{}{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
 							"name":  "web",
 							"image": "nginx:1." + revision,
 						},
@@ -47,7 +47,7 @@ func testReplicaSet(name, ns, revision, ownerName string) *unstructured.Unstruct
 				},
 			},
 		},
-		"status": map[string]interface{}{
+		"status": map[string]any{
 			"replicas":      int64(3),
 			"readyReplicas": int64(3),
 		},
@@ -82,12 +82,12 @@ func TestRolloutHistory_DeploymentAllRevisions(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}
 
-	revisions, ok := result["revisions"].([]interface{})
+	revisions, ok := result["revisions"].([]any)
 	if !ok {
 		t.Fatalf("expected revisions array, got: %v", result["revisions"])
 	}
@@ -96,11 +96,11 @@ func TestRolloutHistory_DeploymentAllRevisions(t *testing.T) {
 	}
 
 	// Verify sorted by revision number.
-	rev1 := revisions[0].(map[string]interface{})
+	rev1 := revisions[0].(map[string]any)
 	if rev1["revision"].(float64) != 1 {
 		t.Errorf("expected first revision=1, got %v", rev1["revision"])
 	}
-	rev3 := revisions[2].(map[string]interface{})
+	rev3 := revisions[2].(map[string]any)
 	if rev3["revision"].(float64) != 3 {
 		t.Errorf("expected last revision=3, got %v", rev3["revision"])
 	}
@@ -134,7 +134,7 @@ func TestRolloutHistory_DeploymentSpecificRevision(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}
@@ -231,12 +231,12 @@ func TestRolloutHistory_NoReplicaSetsFound(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}
 
-	revisions := result["revisions"].([]interface{})
+	revisions := result["revisions"].([]any)
 	if len(revisions) != 0 {
 		t.Errorf("expected 0 revisions, got %d", len(revisions))
 	}
@@ -291,12 +291,12 @@ func TestRolloutHistory_FiltersUnrelatedReplicaSets(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}
 
-	revisions := result["revisions"].([]interface{})
+	revisions := result["revisions"].([]any)
 	if len(revisions) != 1 {
 		t.Errorf("expected 1 revision (only owned by my-deploy), got %d", len(revisions))
 	}

--- a/internal/tools/rollout_status.go
+++ b/internal/tools/rollout_status.go
@@ -99,10 +99,10 @@ func registerRolloutStatus(s *server.MCPServer, pool *kube.ClientPool) {
 
 // buildRolloutStatus extracts status fields from the raw object and determines
 // whether the rollout is complete.
-func buildRolloutStatus(kind, name, namespace string, obj map[string]interface{}) rolloutStatusResult {
-	status, _ := obj["status"].(map[string]interface{})
+func buildRolloutStatus(kind, name, namespace string, obj map[string]any) rolloutStatusResult {
+	status, _ := obj["status"].(map[string]any)
 	if status == nil {
-		status = map[string]interface{}{}
+		status = map[string]any{}
 	}
 
 	result := rolloutStatusResult{
@@ -127,8 +127,8 @@ func buildRolloutStatus(kind, name, namespace string, obj map[string]interface{}
 	return result
 }
 
-func deploymentComplete(obj, status map[string]interface{}, replicas map[string]int64) bool {
-	spec, _ := obj["spec"].(map[string]interface{})
+func deploymentComplete(obj, status map[string]any, replicas map[string]int64) bool {
+	spec, _ := obj["spec"].(map[string]any)
 	desired := toInt64(spec, "replicas")
 	ready := toInt64(status, "readyReplicas")
 	updated := toInt64(status, "updatedReplicas")
@@ -142,8 +142,8 @@ func deploymentComplete(obj, status map[string]interface{}, replicas map[string]
 	return desired > 0 && ready == desired && updated == desired && available == desired
 }
 
-func statefulSetComplete(obj, status map[string]interface{}, replicas map[string]int64) bool {
-	spec, _ := obj["spec"].(map[string]interface{})
+func statefulSetComplete(obj, status map[string]any, replicas map[string]int64) bool {
+	spec, _ := obj["spec"].(map[string]any)
 	desired := toInt64(spec, "replicas")
 	ready := toInt64(status, "readyReplicas")
 	updated := toInt64(status, "updatedReplicas")
@@ -155,7 +155,7 @@ func statefulSetComplete(obj, status map[string]interface{}, replicas map[string
 	return desired > 0 && ready == desired && updated == desired
 }
 
-func daemonSetComplete(status map[string]interface{}, replicas map[string]int64) bool {
+func daemonSetComplete(status map[string]any, replicas map[string]int64) bool {
 	desired := toInt64(status, "desiredNumberScheduled")
 	ready := toInt64(status, "numberReady")
 	updated := toInt64(status, "updatedNumberScheduled")
@@ -170,15 +170,15 @@ func daemonSetComplete(status map[string]interface{}, replicas map[string]int64)
 }
 
 // extractConditions pulls condition entries from the status object.
-func extractConditions(status map[string]interface{}) []statusCondition {
-	raw, ok := status["conditions"].([]interface{})
+func extractConditions(status map[string]any) []statusCondition {
+	raw, ok := status["conditions"].([]any)
 	if !ok {
 		return nil
 	}
 
 	conditions := make([]statusCondition, 0, len(raw))
 	for _, item := range raw {
-		m, ok := item.(map[string]interface{})
+		m, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -193,7 +193,7 @@ func extractConditions(status map[string]interface{}) []statusCondition {
 }
 
 // toInt64 safely extracts an int64 from an unstructured map.
-func toInt64(m map[string]interface{}, key string) int64 {
+func toInt64(m map[string]any, key string) int64 {
 	if m == nil {
 		return 0
 	}
@@ -214,7 +214,7 @@ func toInt64(m map[string]interface{}, key string) int64 {
 }
 
 // toString safely extracts a string from an unstructured map.
-func toString(m map[string]interface{}, key string) string {
+func toString(m map[string]any, key string) string {
 	if m == nil {
 		return ""
 	}

--- a/internal/tools/rollout_status_test.go
+++ b/internal/tools/rollout_status_test.go
@@ -14,30 +14,30 @@ import (
 )
 
 func testDeploymentWithStatus(name, ns string, replicas, ready, updated, available int64) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "apps/v1",
 		"kind":       "Deployment",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              name,
 			"namespace":         ns,
 			"creationTimestamp": "2024-01-01T00:00:00Z",
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"replicas": replicas,
 		},
-		"status": map[string]interface{}{
+		"status": map[string]any{
 			"replicas":          replicas,
 			"readyReplicas":     ready,
 			"updatedReplicas":   updated,
 			"availableReplicas": available,
-			"conditions": []interface{}{
-				map[string]interface{}{
+			"conditions": []any{
+				map[string]any{
 					"type":    "Available",
 					"status":  "True",
 					"reason":  "MinimumReplicasAvailable",
 					"message": "Deployment has minimum availability.",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"type":    "Progressing",
 					"status":  "True",
 					"reason":  "NewReplicaSetAvailable",
@@ -49,18 +49,18 @@ func testDeploymentWithStatus(name, ns string, replicas, ready, updated, availab
 }
 
 func testStatefulSetWithStatus(name, ns string, replicas, ready, updated int64) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "apps/v1",
 		"kind":       "StatefulSet",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              name,
 			"namespace":         ns,
 			"creationTimestamp": "2024-01-01T00:00:00Z",
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"replicas": replicas,
 		},
-		"status": map[string]interface{}{
+		"status": map[string]any{
 			"replicas":        replicas,
 			"readyReplicas":   ready,
 			"updatedReplicas": updated,
@@ -69,15 +69,15 @@ func testStatefulSetWithStatus(name, ns string, replicas, ready, updated int64) 
 }
 
 func testDaemonSetWithStatus(name, ns string, desired, ready, updated, available int64) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "apps/v1",
 		"kind":       "DaemonSet",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              name,
 			"namespace":         ns,
 			"creationTimestamp": "2024-01-01T00:00:00Z",
 		},
-		"status": map[string]interface{}{
+		"status": map[string]any{
 			"desiredNumberScheduled": desired,
 			"numberReady":            ready,
 			"updatedNumberScheduled": updated,
@@ -110,7 +110,7 @@ func TestRolloutStatus_DeploymentComplete(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}
@@ -147,7 +147,7 @@ func TestRolloutStatus_DeploymentInProgress(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}
@@ -178,7 +178,7 @@ func TestRolloutStatus_StatefulSet(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}
@@ -212,7 +212,7 @@ func TestRolloutStatus_DaemonSet(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		t.Fatalf("expected JSON output, got: %s", text)
 	}

--- a/internal/tools/rollout_undo.go
+++ b/internal/tools/rollout_undo.go
@@ -83,8 +83,8 @@ func registerRolloutUndo(s *server.MCPServer, pool *kube.ClientPool, cfg *config
 		}
 
 		// Patch the Deployment's spec.template with the target template.
-		patch := map[string]interface{}{
-			"spec": map[string]interface{}{
+		patch := map[string]any{
+			"spec": map[string]any{
 				"template": template,
 			},
 		}
@@ -158,12 +158,12 @@ func findTargetRS(rsList []unstructured.Unstructured, toRevision int64) (unstruc
 }
 
 // extractPodTemplate pulls spec.template from a ReplicaSet.
-func extractPodTemplate(rs unstructured.Unstructured) (map[string]interface{}, error) {
-	spec, ok := rs.Object["spec"].(map[string]interface{})
+func extractPodTemplate(rs unstructured.Unstructured) (map[string]any, error) {
+	spec, ok := rs.Object["spec"].(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("missing spec")
 	}
-	template, ok := spec["template"].(map[string]interface{})
+	template, ok := spec["template"].(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("missing spec.template")
 	}

--- a/internal/tools/run.go
+++ b/internal/tools/run.go
@@ -86,7 +86,7 @@ func registerRunPod(s *server.MCPServer, pool *kube.ClientPool, cfg *config.Conf
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		container := map[string]interface{}{
+		container := map[string]any{
 			"name":  name,
 			"image": image,
 		}
@@ -96,7 +96,7 @@ func registerRunPod(s *server.MCPServer, pool *kube.ClientPool, cfg *config.Conf
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("invalid command: %v", err)), nil
 			}
-			cmdSlice := make([]interface{}, len(parts))
+			cmdSlice := make([]any, len(parts))
 			for i, p := range parts {
 				cmdSlice[i] = p
 			}
@@ -104,7 +104,7 @@ func registerRunPod(s *server.MCPServer, pool *kube.ClientPool, cfg *config.Conf
 		}
 
 		if len(containerPorts) > 0 {
-			portsSlice := make([]interface{}, len(containerPorts))
+			portsSlice := make([]any, len(containerPorts))
 			for i, p := range containerPorts {
 				portsSlice[i] = p
 			}
@@ -112,16 +112,16 @@ func registerRunPod(s *server.MCPServer, pool *kube.ClientPool, cfg *config.Conf
 		}
 
 		pod := &unstructured.Unstructured{
-			Object: map[string]interface{}{
+			Object: map[string]any{
 				"apiVersion": "v1",
 				"kind":       "Pod",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      name,
 					"namespace": namespace,
 				},
-				"spec": map[string]interface{}{
+				"spec": map[string]any{
 					"restartPolicy": restartPolicy,
-					"containers":    []interface{}{container},
+					"containers":    []any{container},
 				},
 			},
 		}
@@ -136,7 +136,7 @@ func registerRunPod(s *server.MCPServer, pool *kube.ClientPool, cfg *config.Conf
 		}
 
 		// Strip managedFields for cleaner output.
-		if md, ok := result.Object["metadata"].(map[string]interface{}); ok {
+		if md, ok := result.Object["metadata"].(map[string]any); ok {
 			delete(md, "managedFields")
 		}
 
@@ -160,14 +160,14 @@ var validProtocols = map[string]bool{
 // parsePortsString parses a comma-separated ports string like "80", "80,443",
 // or "8080/TCP,9090/UDP" into a slice of container port maps ready for an
 // unstructured Pod spec.
-func parsePortsString(ports string) ([]map[string]interface{}, error) {
+func parsePortsString(ports string) ([]map[string]any, error) {
 	ports = strings.TrimSpace(ports)
 	if ports == "" {
 		return nil, nil
 	}
 
 	parts := strings.Split(ports, ",")
-	result := make([]map[string]interface{}, 0, len(parts))
+	result := make([]map[string]any, 0, len(parts))
 
 	for _, part := range parts {
 		part = strings.TrimSpace(part)
@@ -178,9 +178,9 @@ func parsePortsString(ports string) ([]map[string]interface{}, error) {
 		portStr := part
 		protocol := "TCP"
 
-		if idx := strings.Index(part, "/"); idx >= 0 {
-			portStr = part[:idx]
-			protocol = strings.ToUpper(part[idx+1:])
+		if before, after, ok := strings.Cut(part, "/"); ok {
+			portStr = before
+			protocol = strings.ToUpper(after)
 		}
 
 		if !validProtocols[protocol] {
@@ -195,7 +195,7 @@ func parsePortsString(ports string) ([]map[string]interface{}, error) {
 			return nil, fmt.Errorf("invalid port %d: must be between 1 and 65535", portNum)
 		}
 
-		result = append(result, map[string]interface{}{
+		result = append(result, map[string]any{
 			"containerPort": portNum,
 			"protocol":      protocol,
 		})

--- a/internal/tools/run_test.go
+++ b/internal/tools/run_test.go
@@ -82,10 +82,10 @@ func TestRunPod_WithCommand(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	spec := created.Object["spec"].(map[string]interface{})
-	containers := spec["containers"].([]interface{})
-	container := containers[0].(map[string]interface{})
-	command := container["command"].([]interface{})
+	spec := created.Object["spec"].(map[string]any)
+	containers := spec["containers"].([]any)
+	container := containers[0].(map[string]any)
+	command := container["command"].([]any)
 	if len(command) != 3 {
 		t.Errorf("expected 3 command parts, got %d: %v", len(command), command)
 	}
@@ -120,7 +120,7 @@ func TestRunPod_WithRestartPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	spec := created.Object["spec"].(map[string]interface{})
+	spec := created.Object["spec"].(map[string]any)
 	if spec["restartPolicy"] != "OnFailure" {
 		t.Errorf("expected restartPolicy=OnFailure, got %v", spec["restartPolicy"])
 	}
@@ -153,7 +153,7 @@ func TestRunPod_DefaultRestartPolicyNever(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	spec := created.Object["spec"].(map[string]interface{})
+	spec := created.Object["spec"].(map[string]any)
 	if spec["restartPolicy"] != "Never" {
 		t.Errorf("expected default restartPolicy=Never, got %v", spec["restartPolicy"])
 	}
@@ -211,7 +211,7 @@ func TestRunPod_OutputContainsPodSpec(t *testing.T) {
 
 	text := resultText(t, res)
 	// Output should contain JSON of the created pod.
-	var result map[string]interface{}
+	var result map[string]any
 	// Find the JSON part after the "Created Pod" message.
 	idx := strings.Index(text, "{")
 	if idx < 0 {
@@ -282,14 +282,14 @@ func TestRunPod_WithSinglePort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	spec := created.Object["spec"].(map[string]interface{})
-	containers := spec["containers"].([]interface{})
-	container := containers[0].(map[string]interface{})
-	ports, ok := container["ports"].([]interface{})
+	spec := created.Object["spec"].(map[string]any)
+	containers := spec["containers"].([]any)
+	container := containers[0].(map[string]any)
+	ports, ok := container["ports"].([]any)
 	if !ok || len(ports) != 1 {
 		t.Fatalf("expected 1 port, got: %v", container["ports"])
 	}
-	p := ports[0].(map[string]interface{})
+	p := ports[0].(map[string]any)
 	if p["containerPort"] != int64(80) {
 		t.Errorf("expected containerPort=80, got: %v", p["containerPort"])
 	}
@@ -326,15 +326,15 @@ func TestRunPod_WithMultiplePorts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	spec := created.Object["spec"].(map[string]interface{})
-	containers := spec["containers"].([]interface{})
-	container := containers[0].(map[string]interface{})
-	ports := container["ports"].([]interface{})
+	spec := created.Object["spec"].(map[string]any)
+	containers := spec["containers"].([]any)
+	container := containers[0].(map[string]any)
+	ports := container["ports"].([]any)
 	if len(ports) != 2 {
 		t.Fatalf("expected 2 ports, got %d", len(ports))
 	}
-	p0 := ports[0].(map[string]interface{})
-	p1 := ports[1].(map[string]interface{})
+	p0 := ports[0].(map[string]any)
+	p1 := ports[1].(map[string]any)
 	if p0["containerPort"] != int64(80) {
 		t.Errorf("expected first port=80, got: %v", p0["containerPort"])
 	}
@@ -371,15 +371,15 @@ func TestRunPod_WithProtocol(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	spec := created.Object["spec"].(map[string]interface{})
-	containers := spec["containers"].([]interface{})
-	container := containers[0].(map[string]interface{})
-	ports := container["ports"].([]interface{})
+	spec := created.Object["spec"].(map[string]any)
+	containers := spec["containers"].([]any)
+	container := containers[0].(map[string]any)
+	ports := container["ports"].([]any)
 	if len(ports) != 2 {
 		t.Fatalf("expected 2 ports, got %d", len(ports))
 	}
-	p0 := ports[0].(map[string]interface{})
-	p1 := ports[1].(map[string]interface{})
+	p0 := ports[0].(map[string]any)
+	p1 := ports[1].(map[string]any)
 	if p0["protocol"] != "TCP" {
 		t.Errorf("expected protocol=TCP, got: %v", p0["protocol"])
 	}

--- a/internal/tools/safetydelay.go
+++ b/internal/tools/safetydelay.go
@@ -16,19 +16,13 @@ func applySafetyDelay(ctx context.Context, req mcp.CallToolRequest, delay time.D
 		return nil
 	}
 
-	total := int(delay.Seconds())
-	if total < 1 {
-		total = 1
-	}
+	total := max(int(delay.Seconds()), 1)
 
 	elapsed := 0
 	remaining := delay
 
 	for remaining > 0 {
-		tick := time.Second
-		if remaining < tick {
-			tick = remaining
-		}
+		tick := min(remaining, time.Second)
 
 		msg := fmt.Sprintf("safety delay: %ds remaining", int(remaining.Seconds()))
 		sendProgress(ctx, req, elapsed, total, msg)

--- a/internal/tools/scale.go
+++ b/internal/tools/scale.go
@@ -103,7 +103,7 @@ func registerScaleResource(s *server.MCPServer, pool *kube.ClientPool, cfg *conf
 			return mcp.NewToolResultError(fmt.Sprintf("failed to scale %s/%s: %v", kind, name, err)), nil
 		}
 
-		result := map[string]interface{}{
+		result := map[string]any{
 			"kind":        kind,
 			"name":        name,
 			"namespace":   namespace,

--- a/internal/tools/scale_test.go
+++ b/internal/tools/scale_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/tamcore/kubectl-mcp/internal/config"
 )
 
-func int32Ptr(i int32) *int32 { return &i }
-
 func newScaleFakeClientset(objs ...runtime.Object) *fake.Clientset {
 	fakeCS := fake.NewClientset(objs...)
 
@@ -96,7 +94,7 @@ func TestScaleResource_Deployment(t *testing.T) {
 
 	deploy := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-deploy", Namespace: "default"},
-		Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(3)},
+		Spec:       appsv1.DeploymentSpec{Replicas: new(int32(3))},
 	}
 	fakeCS := newScaleFakeClientset(deploy)
 	dynClient := newWriteFakeDynClient()
@@ -131,7 +129,7 @@ func TestScaleResource_StatefulSet(t *testing.T) {
 
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-sts", Namespace: "default"},
-		Spec:       appsv1.StatefulSetSpec{Replicas: int32Ptr(2)},
+		Spec:       appsv1.StatefulSetSpec{Replicas: new(int32(2))},
 	}
 	fakeCS := newScaleFakeClientset(sts)
 	dynClient := newWriteFakeDynClient()
@@ -166,7 +164,7 @@ func TestScaleResource_ReplicaSet(t *testing.T) {
 
 	rs := &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-rs", Namespace: "default"},
-		Spec:       appsv1.ReplicaSetSpec{Replicas: int32Ptr(1)},
+		Spec:       appsv1.ReplicaSetSpec{Replicas: new(int32(1))},
 	}
 	fakeCS := newScaleFakeClientset(rs)
 	dynClient := newWriteFakeDynClient()

--- a/internal/tools/strip.go
+++ b/internal/tools/strip.go
@@ -1,5 +1,7 @@
 package tools
 
+import "maps"
+
 // noisyMetadataKeys lists metadata fields that are stripped to reduce token usage.
 var noisyMetadataKeys = []string{
 	"uid",
@@ -15,14 +17,14 @@ var noisyMetadataKeys = []string{
 // metadata are also removed.
 //
 // The input map is never mutated.
-func StripNoisyMetadata(obj map[string]interface{}) map[string]interface{} {
+func StripNoisyMetadata(obj map[string]any) map[string]any {
 	result := shallowCopyMap(obj)
 
 	rawMeta, ok := result["metadata"]
 	if !ok {
 		return result
 	}
-	metaMap, ok := rawMeta.(map[string]interface{})
+	metaMap, ok := rawMeta.(map[string]any)
 	if !ok {
 		return result
 	}
@@ -46,25 +48,23 @@ func StripNoisyMetadata(obj map[string]interface{}) map[string]interface{} {
 }
 
 // shallowCopyMap returns a new map with the same key-value pairs.
-func shallowCopyMap(m map[string]interface{}) map[string]interface{} {
-	cp := make(map[string]interface{}, len(m))
-	for k, v := range m {
-		cp[k] = v
-	}
+func shallowCopyMap(m map[string]any) map[string]any {
+	cp := make(map[string]any, len(m))
+	maps.Copy(cp, m)
 	return cp
 }
 
 // isEmpty returns true for nil, empty string, empty map, or empty slice values.
-func isEmpty(v interface{}) bool {
+func isEmpty(v any) bool {
 	if v == nil {
 		return true
 	}
 	switch val := v.(type) {
 	case string:
 		return val == ""
-	case map[string]interface{}:
+	case map[string]any:
 		return len(val) == 0
-	case []interface{}:
+	case []any:
 		return len(val) == 0
 	default:
 		return false

--- a/internal/tools/strip_test.go
+++ b/internal/tools/strip_test.go
@@ -7,22 +7,22 @@ import (
 func TestStripNoisyMetadata(t *testing.T) {
 	tests := []struct {
 		name    string
-		input   map[string]interface{}
-		checkFn func(t *testing.T, result map[string]interface{})
+		input   map[string]any
+		checkFn func(t *testing.T, result map[string]any)
 	}{
 		{
 			name: "removes uid and resourceVersion",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"apiVersion": "v1",
 				"kind":       "Pod",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":            "my-pod",
 					"uid":             "abc-123",
 					"resourceVersion": "999",
 				},
 			},
-			checkFn: func(t *testing.T, result map[string]interface{}) {
-				meta := result["metadata"].(map[string]interface{})
+			checkFn: func(t *testing.T, result map[string]any) {
+				meta := result["metadata"].(map[string]any)
 				if _, ok := meta["uid"]; ok {
 					t.Error("uid should be removed")
 				}
@@ -36,15 +36,15 @@ func TestStripNoisyMetadata(t *testing.T) {
 		},
 		{
 			name: "removes generation and selfLink",
-			input: map[string]interface{}{
-				"metadata": map[string]interface{}{
+			input: map[string]any{
+				"metadata": map[string]any{
 					"name":       "test",
 					"generation": int64(5),
 					"selfLink":   "/api/v1/pods/test",
 				},
 			},
-			checkFn: func(t *testing.T, result map[string]interface{}) {
-				meta := result["metadata"].(map[string]interface{})
+			checkFn: func(t *testing.T, result map[string]any) {
+				meta := result["metadata"].(map[string]any)
 				if _, ok := meta["generation"]; ok {
 					t.Error("generation should be removed")
 				}
@@ -55,16 +55,16 @@ func TestStripNoisyMetadata(t *testing.T) {
 		},
 		{
 			name: "removes managedFields",
-			input: map[string]interface{}{
-				"metadata": map[string]interface{}{
+			input: map[string]any{
+				"metadata": map[string]any{
 					"name": "test",
-					"managedFields": []interface{}{
-						map[string]interface{}{"manager": "kubectl"},
+					"managedFields": []any{
+						map[string]any{"manager": "kubectl"},
 					},
 				},
 			},
-			checkFn: func(t *testing.T, result map[string]interface{}) {
-				meta := result["metadata"].(map[string]interface{})
+			checkFn: func(t *testing.T, result map[string]any) {
+				meta := result["metadata"].(map[string]any)
 				if _, ok := meta["managedFields"]; ok {
 					t.Error("managedFields should be removed")
 				}
@@ -72,14 +72,14 @@ func TestStripNoisyMetadata(t *testing.T) {
 		},
 		{
 			name: "removes empty string values from metadata",
-			input: map[string]interface{}{
-				"metadata": map[string]interface{}{
+			input: map[string]any{
+				"metadata": map[string]any{
 					"name":         "test",
 					"generateName": "",
 				},
 			},
-			checkFn: func(t *testing.T, result map[string]interface{}) {
-				meta := result["metadata"].(map[string]interface{})
+			checkFn: func(t *testing.T, result map[string]any) {
+				meta := result["metadata"].(map[string]any)
 				if _, ok := meta["generateName"]; ok {
 					t.Error("empty string should be removed")
 				}
@@ -87,14 +87,14 @@ func TestStripNoisyMetadata(t *testing.T) {
 		},
 		{
 			name: "removes nil values from metadata",
-			input: map[string]interface{}{
-				"metadata": map[string]interface{}{
+			input: map[string]any{
+				"metadata": map[string]any{
 					"name":      "test",
 					"nullField": nil,
 				},
 			},
-			checkFn: func(t *testing.T, result map[string]interface{}) {
-				meta := result["metadata"].(map[string]interface{})
+			checkFn: func(t *testing.T, result map[string]any) {
+				meta := result["metadata"].(map[string]any)
 				if _, ok := meta["nullField"]; ok {
 					t.Error("nil value should be removed")
 				}
@@ -102,14 +102,14 @@ func TestStripNoisyMetadata(t *testing.T) {
 		},
 		{
 			name: "removes empty map values from metadata",
-			input: map[string]interface{}{
-				"metadata": map[string]interface{}{
+			input: map[string]any{
+				"metadata": map[string]any{
 					"name":   "test",
-					"labels": map[string]interface{}{},
+					"labels": map[string]any{},
 				},
 			},
-			checkFn: func(t *testing.T, result map[string]interface{}) {
-				meta := result["metadata"].(map[string]interface{})
+			checkFn: func(t *testing.T, result map[string]any) {
+				meta := result["metadata"].(map[string]any)
 				if _, ok := meta["labels"]; ok {
 					t.Error("empty map should be removed")
 				}
@@ -117,14 +117,14 @@ func TestStripNoisyMetadata(t *testing.T) {
 		},
 		{
 			name: "removes empty slice values from metadata",
-			input: map[string]interface{}{
-				"metadata": map[string]interface{}{
+			input: map[string]any{
+				"metadata": map[string]any{
 					"name":       "test",
-					"finalizers": []interface{}{},
+					"finalizers": []any{},
 				},
 			},
-			checkFn: func(t *testing.T, result map[string]interface{}) {
-				meta := result["metadata"].(map[string]interface{})
+			checkFn: func(t *testing.T, result map[string]any) {
+				meta := result["metadata"].(map[string]any)
 				if _, ok := meta["finalizers"]; ok {
 					t.Error("empty slice should be removed")
 				}
@@ -132,17 +132,17 @@ func TestStripNoisyMetadata(t *testing.T) {
 		},
 		{
 			name: "preserves non-empty metadata fields",
-			input: map[string]interface{}{
-				"metadata": map[string]interface{}{
+			input: map[string]any{
+				"metadata": map[string]any{
 					"name":              "test",
 					"namespace":         "default",
 					"creationTimestamp": "2024-01-01T00:00:00Z",
-					"labels":            map[string]interface{}{"app": "web"},
-					"annotations":       map[string]interface{}{"note": "hello"},
+					"labels":            map[string]any{"app": "web"},
+					"annotations":       map[string]any{"note": "hello"},
 				},
 			},
-			checkFn: func(t *testing.T, result map[string]interface{}) {
-				meta := result["metadata"].(map[string]interface{})
+			checkFn: func(t *testing.T, result map[string]any) {
+				meta := result["metadata"].(map[string]any)
 				for _, key := range []string{"name", "namespace", "creationTimestamp", "labels", "annotations"} {
 					if _, ok := meta[key]; !ok {
 						t.Errorf("expected %q to be preserved", key)
@@ -152,21 +152,21 @@ func TestStripNoisyMetadata(t *testing.T) {
 		},
 		{
 			name: "does not mutate input",
-			input: map[string]interface{}{
-				"metadata": map[string]interface{}{
+			input: map[string]any{
+				"metadata": map[string]any{
 					"name":            "test",
 					"uid":             "abc",
 					"resourceVersion": "1",
 				},
 			},
-			checkFn: func(t *testing.T, _ map[string]interface{}) {
+			checkFn: func(t *testing.T, _ map[string]any) {
 				// Verified via the separate mutation check below.
 			},
 		},
 		{
 			name:  "handles missing metadata gracefully",
-			input: map[string]interface{}{"apiVersion": "v1"},
-			checkFn: func(t *testing.T, result map[string]interface{}) {
+			input: map[string]any{"apiVersion": "v1"},
+			checkFn: func(t *testing.T, result map[string]any) {
 				if result["apiVersion"] != "v1" {
 					t.Error("apiVersion should be preserved")
 				}
@@ -174,10 +174,10 @@ func TestStripNoisyMetadata(t *testing.T) {
 		},
 		{
 			name: "handles non-map metadata gracefully",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"metadata": "not-a-map",
 			},
-			checkFn: func(t *testing.T, result map[string]interface{}) {
+			checkFn: func(t *testing.T, result map[string]any) {
 				if result["metadata"] != "not-a-map" {
 					t.Error("non-map metadata should be preserved as-is")
 				}
@@ -185,20 +185,20 @@ func TestStripNoisyMetadata(t *testing.T) {
 		},
 		{
 			name: "preserves spec and status",
-			input: map[string]interface{}{
-				"metadata": map[string]interface{}{
+			input: map[string]any{
+				"metadata": map[string]any{
 					"name": "test",
 					"uid":  "abc",
 				},
-				"spec":   map[string]interface{}{"replicas": int64(3)},
-				"status": map[string]interface{}{"phase": "Running"},
+				"spec":   map[string]any{"replicas": int64(3)},
+				"status": map[string]any{"phase": "Running"},
 			},
-			checkFn: func(t *testing.T, result map[string]interface{}) {
-				spec := result["spec"].(map[string]interface{})
+			checkFn: func(t *testing.T, result map[string]any) {
+				spec := result["spec"].(map[string]any)
 				if spec["replicas"] != int64(3) {
 					t.Error("spec should be preserved")
 				}
-				status := result["status"].(map[string]interface{})
+				status := result["status"].(map[string]any)
 				if status["phase"] != "Running" {
 					t.Error("status should be preserved")
 				}
@@ -215,18 +215,18 @@ func TestStripNoisyMetadata(t *testing.T) {
 
 	// Dedicated immutability test.
 	t.Run("immutability", func(t *testing.T) {
-		original := map[string]interface{}{
-			"metadata": map[string]interface{}{
+		original := map[string]any{
+			"metadata": map[string]any{
 				"name":            "test",
 				"uid":             "abc-123",
 				"resourceVersion": "42",
-				"managedFields":   []interface{}{map[string]interface{}{"manager": "x"}},
+				"managedFields":   []any{map[string]any{"manager": "x"}},
 			},
 		}
 
 		_ = StripNoisyMetadata(original)
 
-		meta := original["metadata"].(map[string]interface{})
+		meta := original["metadata"].(map[string]any)
 		if _, ok := meta["uid"]; !ok {
 			t.Error("original uid should not be removed (immutability violated)")
 		}
@@ -242,16 +242,16 @@ func TestStripNoisyMetadata(t *testing.T) {
 func TestIsEmpty(t *testing.T) {
 	tests := []struct {
 		name string
-		val  interface{}
+		val  any
 		want bool
 	}{
 		{"nil", nil, true},
 		{"empty string", "", true},
 		{"non-empty string", "hello", false},
-		{"empty map", map[string]interface{}{}, true},
-		{"non-empty map", map[string]interface{}{"a": 1}, false},
-		{"empty slice", []interface{}{}, true},
-		{"non-empty slice", []interface{}{1}, false},
+		{"empty map", map[string]any{}, true},
+		{"non-empty map", map[string]any{"a": 1}, false},
+		{"empty slice", []any{}, true},
+		{"non-empty slice", []any{1}, false},
 		{"int64", int64(0), false},
 		{"bool false", false, false},
 	}

--- a/internal/tools/structured_test.go
+++ b/internal/tools/structured_test.go
@@ -37,13 +37,13 @@ func TestGetResource_HasStructuredContent(t *testing.T) {
 	}
 
 	// Verify it's the right type (map).
-	obj, ok := res.StructuredContent.(map[string]interface{})
+	obj, ok := res.StructuredContent.(map[string]any)
 	if !ok {
 		t.Fatalf("expected StructuredContent to be map[string]interface{}, got %T", res.StructuredContent)
 	}
 
 	// Verify it contains the pod name.
-	meta, ok := obj["metadata"].(map[string]interface{})
+	meta, ok := obj["metadata"].(map[string]any)
 	if !ok {
 		t.Fatal("expected metadata in structured content")
 	}
@@ -85,7 +85,7 @@ func TestListResources_HasStructuredContent(t *testing.T) {
 	}
 
 	// Verify it's an object envelope (not a raw array).
-	envelope, ok := res.StructuredContent.(map[string]interface{})
+	envelope, ok := res.StructuredContent.(map[string]any)
 	if !ok {
 		t.Fatalf("expected StructuredContent to be map[string]interface{}, got %T", res.StructuredContent)
 	}
@@ -95,7 +95,7 @@ func TestListResources_HasStructuredContent(t *testing.T) {
 	if !ok {
 		t.Fatal("expected 'items' key in structured content envelope")
 	}
-	items, ok := rawItems.([]map[string]interface{})
+	items, ok := rawItems.([]map[string]any)
 	if !ok {
 		t.Fatalf("expected items to be []map[string]interface{}, got %T", rawItems)
 	}
@@ -136,11 +136,11 @@ func TestListResources_SummaryStructuredContentIsCompact(t *testing.T) {
 		t.Fatalf("unexpected error: %s", resultText(t, res))
 	}
 
-	envelope, ok := res.StructuredContent.(map[string]interface{})
+	envelope, ok := res.StructuredContent.(map[string]any)
 	if !ok {
 		t.Fatalf("expected map envelope, got %T", res.StructuredContent)
 	}
-	items, ok := envelope["items"].([]map[string]interface{})
+	items, ok := envelope["items"].([]map[string]any)
 	if !ok {
 		t.Fatalf("expected items to be []map[string]interface{}, got %T", envelope["items"])
 	}
@@ -155,7 +155,7 @@ func TestListResources_SummaryStructuredContentIsCompact(t *testing.T) {
 	}
 	if statusVal, hasStatus := item["status"]; hasStatus {
 		// "status" as a string (e.g. "Running") is fine; as a map is not.
-		if _, isMap := statusVal.(map[string]interface{}); isMap {
+		if _, isMap := statusVal.(map[string]any); isMap {
 			t.Error("summary structuredContent should NOT contain 'status' as a nested object (full object leaked)")
 		}
 	}

--- a/internal/tools/top.go
+++ b/internal/tools/top.go
@@ -202,17 +202,17 @@ func registerTopPods(s *server.MCPServer, pool *kube.ClientPool) {
 
 // sumContainerUsage sums CPU (millicores) and memory (bytes) across all
 // containers in a PodMetrics unstructured object.
-func sumContainerUsage(obj map[string]interface{}) (cpuMillis int64, memBytes int64) {
-	containers, ok := obj["containers"].([]interface{})
+func sumContainerUsage(obj map[string]any) (cpuMillis int64, memBytes int64) {
+	containers, ok := obj["containers"].([]any)
 	if !ok {
 		return 0, 0
 	}
 	for _, c := range containers {
-		cm, ok := c.(map[string]interface{})
+		cm, ok := c.(map[string]any)
 		if !ok {
 			continue
 		}
-		usage, ok := cm["usage"].(map[string]interface{})
+		usage, ok := cm["usage"].(map[string]any)
 		if !ok {
 			continue
 		}
@@ -237,18 +237,18 @@ type containerMetric struct {
 }
 
 // eachContainerUsage returns per-container CPU and memory from a PodMetrics object.
-func eachContainerUsage(obj map[string]interface{}) []containerMetric {
-	containers, ok := obj["containers"].([]interface{})
+func eachContainerUsage(obj map[string]any) []containerMetric {
+	containers, ok := obj["containers"].([]any)
 	if !ok {
 		return nil
 	}
 	result := make([]containerMetric, 0, len(containers))
 	for _, c := range containers {
-		cm, ok := c.(map[string]interface{})
+		cm, ok := c.(map[string]any)
 		if !ok {
 			continue
 		}
-		usage, ok := cm["usage"].(map[string]interface{})
+		usage, ok := cm["usage"].(map[string]any)
 		if !ok {
 			continue
 		}
@@ -378,7 +378,7 @@ func registerTopNodes(s *server.MCPServer, pool *kube.ClientPool) {
 
 		items := make([]nodeUsage, 0, len(metricsList))
 		for _, m := range metricsList {
-			usage, ok := m.Object["usage"].(map[string]interface{})
+			usage, ok := m.Object["usage"].(map[string]any)
 			if !ok {
 				continue
 			}
@@ -422,12 +422,12 @@ type nodeAllocatable struct {
 }
 
 // extractAllocatable pulls .status.allocatable.{cpu,memory} from a Node object.
-func extractAllocatable(obj map[string]interface{}) nodeAllocatable {
-	status, ok := obj["status"].(map[string]interface{})
+func extractAllocatable(obj map[string]any) nodeAllocatable {
+	status, ok := obj["status"].(map[string]any)
 	if !ok {
 		return nodeAllocatable{}
 	}
-	alloc, ok := status["allocatable"].(map[string]interface{})
+	alloc, ok := status["allocatable"].(map[string]any)
 	if !ok {
 		return nodeAllocatable{}
 	}

--- a/internal/tools/top_test.go
+++ b/internal/tools/top_test.go
@@ -25,17 +25,17 @@ import (
 // ---------------------------------------------------------------------------
 
 func testPodMetrics(name, ns, cpu, memory string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "metrics.k8s.io/v1beta1",
 		"kind":       "PodMetrics",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name,
 			"namespace": ns,
 		},
-		"containers": []interface{}{
-			map[string]interface{}{
+		"containers": []any{
+			map[string]any{
 				"name": "main",
-				"usage": map[string]interface{}{
+				"usage": map[string]any{
 					"cpu":    cpu,
 					"memory": memory,
 				},
@@ -44,16 +44,16 @@ func testPodMetrics(name, ns, cpu, memory string) *unstructured.Unstructured {
 	}}
 }
 
-func testPodMetricsMultiContainer(name, ns string, containers []map[string]interface{}) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+func testPodMetricsMultiContainer(name, ns string, containers []map[string]any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "metrics.k8s.io/v1beta1",
 		"kind":       "PodMetrics",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name,
 			"namespace": ns,
 		},
-		"containers": func() []interface{} {
-			out := make([]interface{}, len(containers))
+		"containers": func() []any {
+			out := make([]any, len(containers))
 			for i, c := range containers {
 				out[i] = c
 			}
@@ -63,13 +63,13 @@ func testPodMetricsMultiContainer(name, ns string, containers []map[string]inter
 }
 
 func testNodeMetrics(name, cpu, memory string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "metrics.k8s.io/v1beta1",
 		"kind":       "NodeMetrics",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name": name,
 		},
-		"usage": map[string]interface{}{
+		"usage": map[string]any{
 			"cpu":    cpu,
 			"memory": memory,
 		},
@@ -77,15 +77,15 @@ func testNodeMetrics(name, cpu, memory string) *unstructured.Unstructured {
 }
 
 func testNodeWithAllocatable(name, cpu, memory string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Node",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              name,
 			"creationTimestamp": "2024-01-01T00:00:00Z",
 		},
-		"status": map[string]interface{}{
-			"allocatable": map[string]interface{}{
+		"status": map[string]any{
+			"allocatable": map[string]any{
 				"cpu":    cpu,
 				"memory": memory,
 			},
@@ -216,15 +216,15 @@ func TestFormatPercent(t *testing.T) {
 }
 
 func TestSumContainerUsage_MalformedQuantitySkipped(t *testing.T) {
-	obj := map[string]interface{}{
-		"containers": []interface{}{
-			map[string]interface{}{
+	obj := map[string]any{
+		"containers": []any{
+			map[string]any{
 				"name":  "good",
-				"usage": map[string]interface{}{"cpu": "100m", "memory": "64Mi"},
+				"usage": map[string]any{"cpu": "100m", "memory": "64Mi"},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":  "bad",
-				"usage": map[string]interface{}{"cpu": "garbage", "memory": "also-bad"},
+				"usage": map[string]any{"cpu": "garbage", "memory": "also-bad"},
 			},
 		},
 	}
@@ -239,11 +239,11 @@ func TestSumContainerUsage_MalformedQuantitySkipped(t *testing.T) {
 }
 
 func TestEachContainerUsage_MalformedQuantitySkipped(t *testing.T) {
-	obj := map[string]interface{}{
-		"containers": []interface{}{
-			map[string]interface{}{
+	obj := map[string]any{
+		"containers": []any{
+			map[string]any{
 				"name":  "bad",
-				"usage": map[string]interface{}{"cpu": "nope", "memory": "nope"},
+				"usage": map[string]any{"cpu": "nope", "memory": "nope"},
 			},
 		},
 	}
@@ -259,9 +259,9 @@ func TestEachContainerUsage_MalformedQuantitySkipped(t *testing.T) {
 }
 
 func TestExtractAllocatable_MalformedQuantitySkipped(t *testing.T) {
-	obj := map[string]interface{}{
-		"status": map[string]interface{}{
-			"allocatable": map[string]interface{}{"cpu": "bogus", "memory": "bogus"},
+	obj := map[string]any{
+		"status": map[string]any{
+			"allocatable": map[string]any{"cpu": "bogus", "memory": "bogus"},
 		},
 	}
 
@@ -296,7 +296,7 @@ func TestTopPods_HappyPath(t *testing.T) {
 
 	text := resultText(t, res)
 	// Should be valid JSON array.
-	var items []map[string]interface{}
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(text), &items); err != nil {
 		t.Fatalf("expected JSON array, got: %s", text)
 	}
@@ -334,7 +334,7 @@ func TestTopPods_NamespaceFilter(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var items []map[string]interface{}
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(text), &items); err != nil {
 		t.Fatalf("expected JSON, got: %s", text)
 	}
@@ -368,7 +368,7 @@ func TestTopPods_NameFilter(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var items []map[string]interface{}
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(text), &items); err != nil {
 		t.Fatalf("expected JSON, got: %s", text)
 	}
@@ -383,9 +383,9 @@ func TestTopPods_NameFilter(t *testing.T) {
 func TestTopPods_ContainersBreakdown(t *testing.T) {
 	cfg := defaultCfg()
 	dynClient := newMetricsFakeDynClient(
-		testPodMetricsMultiContainer("pod-1", "default", []map[string]interface{}{
-			{"name": "app", "usage": map[string]interface{}{"cpu": "200m", "memory": "64Mi"}},
-			{"name": "sidecar", "usage": map[string]interface{}{"cpu": "50m", "memory": "32Mi"}},
+		testPodMetricsMultiContainer("pod-1", "default", []map[string]any{
+			{"name": "app", "usage": map[string]any{"cpu": "200m", "memory": "64Mi"}},
+			{"name": "sidecar", "usage": map[string]any{"cpu": "50m", "memory": "32Mi"}},
 		}),
 	)
 	fakeCS := fake.NewClientset()
@@ -404,7 +404,7 @@ func TestTopPods_ContainersBreakdown(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var items []map[string]interface{}
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(text), &items); err != nil {
 		t.Fatalf("expected JSON array, got: %s", text)
 	}
@@ -439,9 +439,9 @@ func TestTopPods_ContainersBreakdown(t *testing.T) {
 func TestTopPods_ContainersFalseAggregates(t *testing.T) {
 	cfg := defaultCfg()
 	dynClient := newMetricsFakeDynClient(
-		testPodMetricsMultiContainer("pod-1", "default", []map[string]interface{}{
-			{"name": "app", "usage": map[string]interface{}{"cpu": "200m", "memory": "64Mi"}},
-			{"name": "sidecar", "usage": map[string]interface{}{"cpu": "50m", "memory": "32Mi"}},
+		testPodMetricsMultiContainer("pod-1", "default", []map[string]any{
+			{"name": "app", "usage": map[string]any{"cpu": "200m", "memory": "64Mi"}},
+			{"name": "sidecar", "usage": map[string]any{"cpu": "50m", "memory": "32Mi"}},
 		}),
 	)
 	fakeCS := fake.NewClientset()
@@ -460,7 +460,7 @@ func TestTopPods_ContainersFalseAggregates(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var items []map[string]interface{}
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(text), &items); err != nil {
 		t.Fatalf("expected JSON, got: %s", text)
 	}
@@ -480,9 +480,9 @@ func TestTopPods_ContainersFalseAggregates(t *testing.T) {
 func TestTopPods_MultiContainer(t *testing.T) {
 	cfg := defaultCfg()
 	dynClient := newMetricsFakeDynClient(
-		testPodMetricsMultiContainer("pod-1", "default", []map[string]interface{}{
-			{"name": "app", "usage": map[string]interface{}{"cpu": "200m", "memory": "64Mi"}},
-			{"name": "sidecar", "usage": map[string]interface{}{"cpu": "50m", "memory": "32Mi"}},
+		testPodMetricsMultiContainer("pod-1", "default", []map[string]any{
+			{"name": "app", "usage": map[string]any{"cpu": "200m", "memory": "64Mi"}},
+			{"name": "sidecar", "usage": map[string]any{"cpu": "50m", "memory": "32Mi"}},
 		}),
 	)
 	fakeCS := fake.NewClientset()
@@ -500,7 +500,7 @@ func TestTopPods_MultiContainer(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var items []map[string]interface{}
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(text), &items); err != nil {
 		t.Fatalf("expected JSON, got: %s", text)
 	}
@@ -609,7 +609,7 @@ func TestTopNodes_HappyPath(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var items []map[string]interface{}
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(text), &items); err != nil {
 		t.Fatalf("expected JSON array, got: %s", text)
 	}
@@ -650,7 +650,7 @@ func TestTopNodes_NameFilter(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var items []map[string]interface{}
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(text), &items); err != nil {
 		t.Fatalf("expected JSON, got: %s", text)
 	}
@@ -681,7 +681,7 @@ func TestTopNodes_MissingAllocatable(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	var items []map[string]interface{}
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(text), &items); err != nil {
 		t.Fatalf("expected JSON, got: %s", text)
 	}
@@ -747,20 +747,20 @@ func TestTopNodes_MetricsServerNotAvailable(t *testing.T) {
 // testNodeWithLabels creates a Node unstructured object with the given labels
 // and allocatable resources, for use in label selector tests.
 func testNodeWithLabels(name, cpu, memory string, lbls map[string]string) *unstructured.Unstructured {
-	labelsMap := make(map[string]interface{}, len(lbls))
+	labelsMap := make(map[string]any, len(lbls))
 	for k, v := range lbls {
 		labelsMap[k] = v
 	}
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Node",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              name,
 			"creationTimestamp": "2024-01-01T00:00:00Z",
 			"labels":            labelsMap,
 		},
-		"status": map[string]interface{}{
-			"allocatable": map[string]interface{}{
+		"status": map[string]any{
+			"allocatable": map[string]any{
 				"cpu":    cpu,
 				"memory": memory,
 			},
@@ -826,7 +826,7 @@ func TestTopNodes_LabelSelector(t *testing.T) {
 		t.Fatalf("expected success, got error: %s", text)
 	}
 
-	var items []map[string]interface{}
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(text), &items); err != nil {
 		t.Fatalf("expected JSON array, got: %s", text)
 	}


### PR DESCRIPTION
Adds a `go-fix` local hook to `.pre-commit-config.yaml` (runs `go fix ./...`) alongside the existing `go fmt` hook, and commits the resulting `go fix` modernizations.