### PR TITLE
feat: require file-to-file transfer for pod copy tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ kube-context. If omitted, the configured default context is used.
 | `list_rbac_bindings` | List ClusterRoleBindings or RoleBindings with optional subject/kind filter |
 | `list_rbac_roles` | List ClusterRoles or Roles; get detailed rules for a named role |
 | `list_service_accounts` | List ServiceAccounts or get details (exposes secret names, never token data) |
-| `copy_from_pod` | Copy a file from a pod container and return its contents (text as-is, binary base64-encoded) |
+| `copy_from_pod` | Copy a file from a pod container; returns contents inline (text as-is, binary base64-encoded), or writes to a local path when `local_path` is given |
 
 ### Write tools (require `--allow-write`)
 
@@ -157,7 +157,7 @@ kube-context. If omitted, the configured default context is used.
 | `rollout_resume` | Resume a paused Deployment rollout |
 | `run_pod` | Create and run a pod with a given image (like `kubectl run`) |
 | `port_forward` | Forward a local port to a pod, service, deployment, or statefulset port (with auto-timeout) |
-| `copy_to_pod` | Copy content to a file in a pod container (use `encoding=base64` for binary data) |
+| `copy_to_pod` | Copy a local file into a pod container (file-to-file, like `kubectl cp`) |
 
 ### Destructive tools (require `--allow-destructive`)
 

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -3,7 +3,8 @@
 package e2e
 
 import (
-	"encoding/base64"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -46,6 +47,37 @@ func TestCopyFromPod(t *testing.T) {
 				}
 			})
 
+			t.Run("to_local_file", func(t *testing.T) {
+				// Write a file via exec, then copy_from_pod into a local file.
+				callTool(t, c, "exec_pod", map[string]any{
+					"namespace": testNamespace,
+					"pod":       podName,
+					"command":   []any{"sh", "-c", "echo 'saved to disk' > /tmp/cp-local.txt"},
+				})
+
+				local := filepath.Join(t.TempDir(), "pulled.txt")
+				result := callTool(t, c, "copy_from_pod", map[string]any{
+					"namespace":  testNamespace,
+					"pod":        podName,
+					"src_path":   "/tmp/cp-local.txt",
+					"local_path": local,
+				})
+				if result.IsError {
+					t.Fatalf("copy_from_pod to local error: %s", resultText(result))
+				}
+				text := resultText(result)
+				if strings.Contains(text, "saved to disk") {
+					t.Errorf("expected metadata-only result, content was echoed: %s", text)
+				}
+				got, err := os.ReadFile(local)
+				if err != nil {
+					t.Fatalf("reading local file: %v", err)
+				}
+				if !strings.Contains(string(got), "saved to disk") {
+					t.Errorf("expected content in local file, got: %q", string(got))
+				}
+			})
+
 			t.Run("nonexistent_file", func(t *testing.T) {
 				result := callTool(t, c, "copy_from_pod", map[string]any{
 					"namespace": testNamespace,
@@ -75,12 +107,17 @@ func TestCopyToPod(t *testing.T) {
 			t.Cleanup(func() { deleteViaKubectl(t, "pod", podName, testNamespace) })
 			waitForPodReady(t, podName, testNamespace)
 
-			t.Run("text_content", func(t *testing.T) {
+			t.Run("local_file", func(t *testing.T) {
+				local := filepath.Join(t.TempDir(), "src.txt")
+				if err := os.WriteFile(local, []byte("injected content\n"), 0644); err != nil {
+					t.Fatalf("writing local file: %v", err)
+				}
+
 				result := callTool(t, c, "copy_to_pod", map[string]any{
-					"namespace": testNamespace,
-					"pod":       podName,
-					"dest_path": "/tmp/injected.txt",
-					"content":   "injected content\n",
+					"namespace":  testNamespace,
+					"pod":        podName,
+					"dest_path":  "/tmp/injected.txt",
+					"local_path": local,
 				})
 				if result.IsError {
 					t.Fatalf("copy_to_pod error: %s", resultText(result))
@@ -99,19 +136,21 @@ func TestCopyToPod(t *testing.T) {
 				}
 			})
 
-			t.Run("base64_content", func(t *testing.T) {
+			t.Run("binary_file", func(t *testing.T) {
 				binaryData := []byte{0x00, 0x01, 0x02, 0x03, 0xff}
-				encoded := base64.StdEncoding.EncodeToString(binaryData)
+				local := filepath.Join(t.TempDir(), "src.bin")
+				if err := os.WriteFile(local, binaryData, 0644); err != nil {
+					t.Fatalf("writing local binary file: %v", err)
+				}
 
 				result := callTool(t, c, "copy_to_pod", map[string]any{
-					"namespace": testNamespace,
-					"pod":       podName,
-					"dest_path": "/tmp/binary.bin",
-					"content":   encoded,
-					"encoding":  "base64",
+					"namespace":  testNamespace,
+					"pod":        podName,
+					"dest_path":  "/tmp/binary.bin",
+					"local_path": local,
 				})
 				if result.IsError {
-					t.Fatalf("copy_to_pod base64 error: %s", resultText(result))
+					t.Fatalf("copy_to_pod binary error: %s", resultText(result))
 				}
 
 				// Verify byte count via exec.
@@ -124,7 +163,7 @@ func TestCopyToPod(t *testing.T) {
 				}
 			})
 
-			})
+		})
 	}
 }
 
@@ -138,10 +177,10 @@ func TestCopyToPod_RejectedWithoutAllowWrite(t *testing.T) {
 			c := tc.clientFunc(t, base)
 
 			_, err := callToolMayFail(t, c, "copy_to_pod", map[string]any{
-				"namespace": testNamespace,
-				"pod":       "any-pod",
-				"dest_path": "/tmp/test.txt",
-				"content":   "data",
+				"namespace":  testNamespace,
+				"pod":        "any-pod",
+				"dest_path":  "/tmp/test.txt",
+				"local_path": "/tmp/whatever",
 			})
 			if err == nil {
 				t.Error("expected error — copy_to_pod should not be registered without --allow-write")

--- a/internal/tools/cp_from_pod.go
+++ b/internal/tools/cp_from_pod.go
@@ -7,6 +7,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"os"
+	"path"
 	"strings"
 	"unicode/utf8"
 
@@ -23,7 +25,7 @@ func registerCopyFromPod(s *server.MCPServer, pool *kube.ClientPool, runner Exec
 	}
 
 	tool := mcp.NewTool("copy_from_pod",
-		mcp.WithDescription("Copy a file from a pod container and return its contents. Text files are returned as-is; binary files are base64-encoded."),
+		mcp.WithDescription("Copy a file from a pod container. Returns contents by default (text as-is, binary base64-encoded); if local_path is set, writes the file there instead (use overwrite=true to replace an existing file)."),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
@@ -45,6 +47,12 @@ func registerCopyFromPod(s *server.MCPServer, pool *kube.ClientPool, runner Exec
 		mcp.WithString("src_path",
 			mcp.Required(),
 			mcp.Description("Absolute path of the file to copy from the container"),
+		),
+		mcp.WithString("local_path",
+			mcp.Description("Absolute local path to write the file to. If set, the file is saved there instead of being returned inline."),
+		),
+		mcp.WithBoolean("overwrite",
+			mcp.Description("Overwrite the local file if it already exists (only used with local_path)"),
 		),
 	)
 
@@ -72,6 +80,21 @@ func registerCopyFromPod(s *server.MCPServer, pool *kube.ClientPool, runner Exec
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 		container := req.GetString("container", "")
+		localPath := req.GetString("local_path", "")
+		overwrite := req.GetBool("overwrite", false)
+
+		if localPath != "" {
+			if !path.IsAbs(localPath) {
+				return mcp.NewToolResultError("local_path must be an absolute path"), nil
+			}
+			if !overwrite {
+				if _, statErr := os.Stat(localPath); statErr == nil {
+					return mcp.NewToolResultError(
+						fmt.Sprintf("local file %s already exists; set overwrite=true to replace it", localPath),
+					), nil
+				}
+			}
+		}
 
 		var stdout, stderr bytes.Buffer
 		if err := runner.Run(ctx, cc.Clientset, cc.RestConfig, namespace, pod, container,
@@ -86,6 +109,15 @@ func registerCopyFromPod(s *server.MCPServer, pool *kube.ClientPool, runner Exec
 		content, err := extractTarFile(&stdout)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to read tar stream: %v", err)), nil
+		}
+
+		if localPath != "" {
+			if err := os.WriteFile(localPath, content, 0644); err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("failed to write local file: %v", err)), nil
+			}
+			return mcp.NewToolResultText(
+				fmt.Sprintf("copied %d bytes from %s:%s to %s", len(content), pod, srcPath, localPath),
+			), nil
 		}
 
 		return mcp.NewToolResultText(formatCopyFromResult(srcPath, content)), nil

--- a/internal/tools/cp_from_pod_test.go
+++ b/internal/tools/cp_from_pod_test.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -78,6 +80,142 @@ func TestCopyFromPod_TextFile(t *testing.T) {
 	}
 	if !strings.Contains(text, "encoding: text") {
 		t.Errorf("expected text encoding, got: %s", text)
+	}
+}
+
+func TestCopyFromPod_WritesLocalFile(t *testing.T) {
+	cfg := defaultCfg()
+	pool := buildWritePool(cfg, newWriteFakeDynClient(), fake.NewClientset())
+
+	tarBytes := buildTar("etc/myconfig", []byte("hello world\n"))
+	runner := &fakeTarExecRunner{tarContent: tarBytes}
+	handler := getHandler(t, "copy_from_pod", func(s *server.MCPServer) {
+		registerCopyFromPod(s, pool, runner, cfg)
+	})
+
+	local := filepath.Join(t.TempDir(), "out.txt")
+	res, err := handler(context.Background(), callToolReq(map[string]any{
+		"namespace":  "default",
+		"pod":        "my-pod",
+		"src_path":   "/etc/myconfig",
+		"local_path": local,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	text := resultText(t, res)
+	// Metadata only — content must NOT be echoed inline.
+	if strings.Contains(text, "hello world") {
+		t.Errorf("expected metadata-only result, but content was echoed: %s", text)
+	}
+	if !strings.Contains(text, local) {
+		t.Errorf("expected local path in result, got: %s", text)
+	}
+
+	got, err := os.ReadFile(local)
+	if err != nil {
+		t.Fatalf("reading written file: %v", err)
+	}
+	if string(got) != "hello world\n" {
+		t.Errorf("expected written file contents, got: %q", string(got))
+	}
+}
+
+func TestCopyFromPod_ExistingFileNoOverwrite(t *testing.T) {
+	cfg := defaultCfg()
+	pool := buildWritePool(cfg, newWriteFakeDynClient(), fake.NewClientset())
+
+	tarBytes := buildTar("etc/myconfig", []byte("new content\n"))
+	runner := &fakeTarExecRunner{tarContent: tarBytes}
+	handler := getHandler(t, "copy_from_pod", func(s *server.MCPServer) {
+		registerCopyFromPod(s, pool, runner, cfg)
+	})
+
+	local := filepath.Join(t.TempDir(), "out.txt")
+	if err := os.WriteFile(local, []byte("original\n"), 0644); err != nil {
+		t.Fatalf("seeding file: %v", err)
+	}
+
+	res, err := handler(context.Background(), callToolReq(map[string]any{
+		"namespace":  "default",
+		"pod":        "my-pod",
+		"src_path":   "/etc/myconfig",
+		"local_path": local,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatal("expected error when local file exists without overwrite")
+	}
+	if !strings.Contains(resultText(t, res), "already exists") {
+		t.Errorf("expected already-exists error, got: %s", resultText(t, res))
+	}
+
+	// Original file must be untouched.
+	got, _ := os.ReadFile(local)
+	if string(got) != "original\n" {
+		t.Errorf("expected original file preserved, got: %q", string(got))
+	}
+}
+
+func TestCopyFromPod_ExistingFileOverwrite(t *testing.T) {
+	cfg := defaultCfg()
+	pool := buildWritePool(cfg, newWriteFakeDynClient(), fake.NewClientset())
+
+	tarBytes := buildTar("etc/myconfig", []byte("new content\n"))
+	runner := &fakeTarExecRunner{tarContent: tarBytes}
+	handler := getHandler(t, "copy_from_pod", func(s *server.MCPServer) {
+		registerCopyFromPod(s, pool, runner, cfg)
+	})
+
+	local := filepath.Join(t.TempDir(), "out.txt")
+	if err := os.WriteFile(local, []byte("original\n"), 0644); err != nil {
+		t.Fatalf("seeding file: %v", err)
+	}
+
+	res, err := handler(context.Background(), callToolReq(map[string]any{
+		"namespace":  "default",
+		"pod":        "my-pod",
+		"src_path":   "/etc/myconfig",
+		"local_path": local,
+		"overwrite":  true,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", resultText(t, res))
+	}
+
+	got, _ := os.ReadFile(local)
+	if string(got) != "new content\n" {
+		t.Errorf("expected file overwritten, got: %q", string(got))
+	}
+}
+
+func TestCopyFromPod_LocalPathNotAbsolute(t *testing.T) {
+	cfg := defaultCfg()
+	pool := buildWritePool(cfg, newWriteFakeDynClient(), fake.NewClientset())
+
+	tarBytes := buildTar("etc/myconfig", []byte("data"))
+	runner := &fakeTarExecRunner{tarContent: tarBytes}
+	handler := getHandler(t, "copy_from_pod", func(s *server.MCPServer) {
+		registerCopyFromPod(s, pool, runner, cfg)
+	})
+
+	res, err := handler(context.Background(), callToolReq(map[string]any{
+		"namespace":  "default",
+		"pod":        "my-pod",
+		"src_path":   "/etc/myconfig",
+		"local_path": "relative/out.txt",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(resultText(t, res), "absolute") {
+		t.Errorf("expected absolute-path error, got: %s", resultText(t, res))
 	}
 }
 

--- a/internal/tools/cp_to_pod.go
+++ b/internal/tools/cp_to_pod.go
@@ -4,9 +4,9 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
-	"encoding/base64"
 	"fmt"
 	"io"
+	"os"
 	"path"
 	"strings"
 
@@ -65,7 +65,7 @@ func registerCopyToPod(s *server.MCPServer, pool *kube.ClientPool, runner CopyRu
 	}
 
 	tool := mcp.NewTool("copy_to_pod",
-		mcp.WithDescription("Copy content to a file in a pod container. Use encoding=base64 for binary data. Requires --allow-write."),
+		mcp.WithDescription("Copy a local file into a pod container (file-to-file, like kubectl cp). Requires --allow-write."),
 		mcp.WithReadOnlyHintAnnotation(false),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(false),
@@ -88,12 +88,9 @@ func registerCopyToPod(s *server.MCPServer, pool *kube.ClientPool, runner CopyRu
 			mcp.Required(),
 			mcp.Description("Absolute destination path inside the container (e.g. /etc/myapp/config.yaml)"),
 		),
-		mcp.WithString("content",
+		mcp.WithString("local_path",
 			mcp.Required(),
-			mcp.Description("File content to write. Plain text by default; base64-encoded bytes when encoding=base64"),
-		),
-		mcp.WithString("encoding",
-			mcp.Description("Content encoding: \"text\" (default) or \"base64\""),
+			mcp.Description("Absolute path to a local file on the machine running the server to copy into the pod (file-to-file, like kubectl cp)"),
 		),
 	)
 
@@ -126,21 +123,31 @@ func registerCopyToPod(s *server.MCPServer, pool *kube.ClientPool, runner CopyRu
 		if strings.Contains(destPath, "..") {
 			return mcp.NewToolResultError("dest_path must not contain '..'"), nil
 		}
-		content, err := req.RequireString("content")
+		localPath, err := req.RequireString("local_path")
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
+		}
+		if !path.IsAbs(localPath) {
+			return mcp.NewToolResultError("local_path must be an absolute path"), nil
 		}
 		container := req.GetString("container", "")
-		encoding := req.GetString("encoding", "text")
 
-		data, err := decodeContent(content, encoding)
+		info, err := os.Stat(localPath)
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			return mcp.NewToolResultError(fmt.Sprintf("cannot read local_path: %v", err)), nil
 		}
-		if len(data) > maxCopyBytes {
+		if info.IsDir() {
+			return mcp.NewToolResultError("local_path is a directory; only single files are supported"), nil
+		}
+		if info.Size() > maxCopyBytes {
 			return mcp.NewToolResultError(
-				fmt.Sprintf("content exceeds maximum allowed size of %d MB", maxCopyBytes/(1024*1024)),
+				fmt.Sprintf("local file exceeds maximum allowed size of %d MB", maxCopyBytes/(1024*1024)),
 			), nil
+		}
+
+		data, err := os.ReadFile(localPath)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to read local file: %v", err)), nil
 		}
 
 		if err := applySafetyDelay(ctx, req, cfg.SafetyDelayWrite); err != nil {
@@ -164,18 +171,6 @@ func registerCopyToPod(s *server.MCPServer, pool *kube.ClientPool, runner CopyRu
 
 		return mcp.NewToolResultText(fmt.Sprintf("copied %d bytes to %s:%s", len(data), pod, destPath)), nil
 	})
-}
-
-// decodeContent returns the raw bytes for the given content and encoding.
-func decodeContent(content, encoding string) ([]byte, error) {
-	if encoding == "base64" {
-		decoded, err := base64.StdEncoding.DecodeString(content)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode base64 content: %w", err)
-		}
-		return decoded, nil
-	}
-	return []byte(content), nil
 }
 
 // buildTarBuffer creates an in-memory tar archive with a single file at destPath.

--- a/internal/tools/cp_to_pod_test.go
+++ b/internal/tools/cp_to_pod_test.go
@@ -4,9 +4,10 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
-	"encoding/base64"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -18,6 +19,16 @@ import (
 
 	"github.com/tamcore/kubectl-mcp/internal/config"
 )
+
+// writeTempFile writes data to a file in a temp dir and returns its absolute path.
+func writeTempFile(t *testing.T, data []byte) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "src")
+	if err := os.WriteFile(p, data, 0644); err != nil {
+		t.Fatalf("writing temp file: %v", err)
+	}
+	return p
+}
 
 // fakeCopyRunner implements CopyRunner for testing.
 type fakeCopyRunner struct {
@@ -45,21 +56,22 @@ func (f *fakeCopyRunner) Run(_ context.Context, _ kubernetes.Interface, _ *rest.
 	return nil
 }
 
-func TestCopyToPod_TextContent(t *testing.T) {
+func TestCopyToPod_LocalFile(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.AllowWrite = true
 	pool := buildWritePool(cfg, newWriteFakeDynClient(), fake.NewClientset())
 
+	local := writeTempFile(t, []byte("hello world\n"))
 	runner := &fakeCopyRunner{}
 	handler := getHandler(t, "copy_to_pod", func(s *server.MCPServer) {
 		registerCopyToPod(s, pool, runner, cfg)
 	})
 
 	res, err := handler(context.Background(), callToolReq(map[string]any{
-		"namespace": "default",
-		"pod":       "my-pod",
-		"dest_path": "/etc/myconfig",
-		"content":   "hello world\n",
+		"namespace":  "default",
+		"pod":        "my-pod",
+		"dest_path":  "/etc/myconfig",
+		"local_path": local,
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -72,27 +84,35 @@ func TestCopyToPod_TextContent(t *testing.T) {
 	if !strings.Contains(text, "my-pod:/etc/myconfig") {
 		t.Errorf("expected pod:path in output, got: %s", text)
 	}
+
+	// Verify the tar sent to the pod contains the file bytes.
+	tr := tar.NewReader(bytes.NewReader(runner.capturedStdin))
+	if _, err := tr.Next(); err != nil {
+		t.Fatalf("could not read tar header: %v", err)
+	}
+	got, _ := io.ReadAll(tr)
+	if string(got) != "hello world\n" {
+		t.Errorf("expected file bytes in tar, got: %q", string(got))
+	}
 }
 
-func TestCopyToPod_Base64Content(t *testing.T) {
+func TestCopyToPod_BinaryFile(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.AllowWrite = true
 	pool := buildWritePool(cfg, newWriteFakeDynClient(), fake.NewClientset())
 
 	binaryData := []byte{0x00, 0x01, 0x02, 0xff}
-	encoded := base64.StdEncoding.EncodeToString(binaryData)
-
+	local := writeTempFile(t, binaryData)
 	runner := &fakeCopyRunner{}
 	handler := getHandler(t, "copy_to_pod", func(s *server.MCPServer) {
 		registerCopyToPod(s, pool, runner, cfg)
 	})
 
 	res, err := handler(context.Background(), callToolReq(map[string]any{
-		"namespace": "default",
-		"pod":       "my-pod",
-		"dest_path": "/data/binary.bin",
-		"content":   encoded,
-		"encoding":  "base64",
+		"namespace":  "default",
+		"pod":        "my-pod",
+		"dest_path":  "/data/binary.bin",
+		"local_path": local,
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -103,10 +123,9 @@ func TestCopyToPod_Base64Content(t *testing.T) {
 		t.Errorf("expected success message, got: %s", text)
 	}
 
-	// Verify the tar sent to the pod contains the decoded binary data.
+	// Verify the tar sent to the pod contains the raw binary bytes.
 	tr := tar.NewReader(bytes.NewReader(runner.capturedStdin))
-	_, err = tr.Next()
-	if err != nil {
+	if _, err := tr.Next(); err != nil {
 		t.Fatalf("could not read tar header: %v", err)
 	}
 	got, _ := io.ReadAll(tr)
@@ -115,7 +134,7 @@ func TestCopyToPod_Base64Content(t *testing.T) {
 	}
 }
 
-func TestCopyToPod_InvalidBase64(t *testing.T) {
+func TestCopyToPod_LocalPathNotAbsolute(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.AllowWrite = true
 	pool := buildWritePool(cfg, newWriteFakeDynClient(), fake.NewClientset())
@@ -126,19 +145,70 @@ func TestCopyToPod_InvalidBase64(t *testing.T) {
 	})
 
 	res, err := handler(context.Background(), callToolReq(map[string]any{
-		"namespace": "default",
-		"pod":       "my-pod",
-		"dest_path": "/data/file",
-		"content":   "not!!valid!!base64!!!",
-		"encoding":  "base64",
+		"namespace":  "default",
+		"pod":        "my-pod",
+		"dest_path":  "/etc/config",
+		"local_path": "relative/file",
 	}))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	text := resultText(t, res)
-	if !strings.Contains(text, "base64") {
-		t.Errorf("expected base64 decode error, got: %s", text)
+	if !strings.Contains(text, "absolute") {
+		t.Errorf("expected absolute-path error, got: %s", text)
+	}
+}
+
+func TestCopyToPod_LocalFileMissing(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.AllowWrite = true
+	pool := buildWritePool(cfg, newWriteFakeDynClient(), fake.NewClientset())
+
+	runner := &fakeCopyRunner{}
+	handler := getHandler(t, "copy_to_pod", func(s *server.MCPServer) {
+		registerCopyToPod(s, pool, runner, cfg)
+	})
+
+	res, err := handler(context.Background(), callToolReq(map[string]any{
+		"namespace":  "default",
+		"pod":        "my-pod",
+		"dest_path":  "/etc/config",
+		"local_path": filepath.Join(t.TempDir(), "does-not-exist"),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	text := resultText(t, res)
+	if !strings.Contains(text, "cannot read local_path") {
+		t.Errorf("expected missing-file error, got: %s", text)
+	}
+}
+
+func TestCopyToPod_LocalPathIsDirectory(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.AllowWrite = true
+	pool := buildWritePool(cfg, newWriteFakeDynClient(), fake.NewClientset())
+
+	runner := &fakeCopyRunner{}
+	handler := getHandler(t, "copy_to_pod", func(s *server.MCPServer) {
+		registerCopyToPod(s, pool, runner, cfg)
+	})
+
+	res, err := handler(context.Background(), callToolReq(map[string]any{
+		"namespace":  "default",
+		"pod":        "my-pod",
+		"dest_path":  "/etc/config",
+		"local_path": t.TempDir(),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	text := resultText(t, res)
+	if !strings.Contains(text, "directory") {
+		t.Errorf("expected directory error, got: %s", text)
 	}
 }
 
@@ -153,9 +223,9 @@ func TestCopyToPod_MissingNamespace(t *testing.T) {
 	})
 
 	res, err := handler(context.Background(), callToolReq(map[string]any{
-		"pod":       "my-pod",
-		"dest_path": "/etc/config",
-		"content":   "data",
+		"pod":        "my-pod",
+		"dest_path":  "/etc/config",
+		"local_path": "/tmp/whatever",
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -178,9 +248,9 @@ func TestCopyToPod_MissingPod(t *testing.T) {
 	})
 
 	res, err := handler(context.Background(), callToolReq(map[string]any{
-		"namespace": "default",
-		"dest_path": "/etc/config",
-		"content":   "data",
+		"namespace":  "default",
+		"dest_path":  "/etc/config",
+		"local_path": "/tmp/whatever",
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -203,9 +273,9 @@ func TestCopyToPod_MissingDestPath(t *testing.T) {
 	})
 
 	res, err := handler(context.Background(), callToolReq(map[string]any{
-		"namespace": "default",
-		"pod":       "my-pod",
-		"content":   "data",
+		"namespace":  "default",
+		"pod":        "my-pod",
+		"local_path": "/tmp/whatever",
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -217,7 +287,7 @@ func TestCopyToPod_MissingDestPath(t *testing.T) {
 	}
 }
 
-func TestCopyToPod_MissingContent(t *testing.T) {
+func TestCopyToPod_MissingLocalPath(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.AllowWrite = true
 	pool := buildWritePool(cfg, newWriteFakeDynClient(), fake.NewClientset())
@@ -237,8 +307,8 @@ func TestCopyToPod_MissingContent(t *testing.T) {
 	}
 
 	text := resultText(t, res)
-	if !strings.Contains(text, "content") {
-		t.Errorf("expected content error, got: %s", text)
+	if !strings.Contains(text, "local_path") {
+		t.Errorf("expected local_path error, got: %s", text)
 	}
 }
 
@@ -252,10 +322,10 @@ func TestCopyToPod_ContextResolutionFailure(t *testing.T) {
 	})
 
 	res, err := handler(context.Background(), callToolReq(map[string]any{
-		"namespace": "default",
-		"pod":       "my-pod",
-		"dest_path": "/etc/config",
-		"content":   "data",
+		"namespace":  "default",
+		"pod":        "my-pod",
+		"dest_path":  "/etc/config",
+		"local_path": "/tmp/whatever",
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -278,10 +348,10 @@ func TestCopyToPod_ExecError(t *testing.T) {
 	})
 
 	res, err := handler(context.Background(), callToolReq(map[string]any{
-		"namespace": "default",
-		"pod":       "my-pod",
-		"dest_path": "/etc/config",
-		"content":   "data",
+		"namespace":  "default",
+		"pod":        "my-pod",
+		"dest_path":  "/etc/config",
+		"local_path": writeTempFile(t, []byte("data")),
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -305,10 +375,10 @@ func TestCopyToPod_SafetyDelay_Disabled(t *testing.T) {
 	})
 
 	res, err := handler(context.Background(), callToolReq(map[string]any{
-		"namespace": "default",
-		"pod":       "my-pod",
-		"dest_path": "/etc/config",
-		"content":   "data",
+		"namespace":  "default",
+		"pod":        "my-pod",
+		"dest_path":  "/etc/config",
+		"local_path": writeTempFile(t, []byte("data")),
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -334,10 +404,10 @@ func TestCopyToPod_TarContainsCorrectPath(t *testing.T) {
 	})
 
 	_, err := handler(context.Background(), callToolReq(map[string]any{
-		"namespace": "default",
-		"pod":       "my-pod",
-		"dest_path": "/etc/myapp/config.yaml",
-		"content":   "key: value\n",
+		"namespace":  "default",
+		"pod":        "my-pod",
+		"dest_path":  "/etc/myapp/config.yaml",
+		"local_path": writeTempFile(t, []byte("key: value\n")),
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -373,10 +443,10 @@ func TestCopyToPod_SafetyDelayInterrupted(t *testing.T) {
 	cancel()
 
 	res, err := handler(ctx, callToolReq(map[string]any{
-		"namespace": "default",
-		"pod":       "my-pod",
-		"dest_path": "/etc/config",
-		"content":   "data",
+		"namespace":  "default",
+		"pod":        "my-pod",
+		"dest_path":  "/etc/config",
+		"local_path": writeTempFile(t, []byte("data")),
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -400,11 +470,11 @@ func TestCopyToPod_WithContainer(t *testing.T) {
 	})
 
 	_, err := handler(context.Background(), callToolReq(map[string]any{
-		"namespace": "default",
-		"pod":       "my-pod",
-		"dest_path": "/cfg",
-		"content":   "data",
-		"container": "sidecar",
+		"namespace":  "default",
+		"pod":        "my-pod",
+		"dest_path":  "/cfg",
+		"local_path": writeTempFile(t, []byte("data")),
+		"container":  "sidecar",
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -440,10 +510,10 @@ func TestCopyToPod_PathValidation(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			res, err := handler(context.Background(), callToolReq(map[string]any{
-				"namespace": "default",
-				"pod":       "my-pod",
-				"dest_path": tc.destPath,
-				"content":   "data",
+				"namespace":  "default",
+				"pod":        "my-pod",
+				"dest_path":  tc.destPath,
+				"local_path": "/tmp/whatever",
 			}))
 			if err != nil {
 				t.Fatal(err)
@@ -494,7 +564,7 @@ func TestBuildTarBuffer_EmptyData(t *testing.T) {
 	}
 }
 
-func TestCopyToPod_ContentTooLarge(t *testing.T) {
+func TestCopyToPod_LocalFileTooLarge(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.AllowWrite = true
 	pool := buildWritePool(cfg, newWriteFakeDynClient(), fake.NewClientset())
@@ -504,20 +574,28 @@ func TestCopyToPod_ContentTooLarge(t *testing.T) {
 		registerCopyToPod(s, pool, runner, cfg)
 	})
 
-	// Send content that is one byte over the limit.
-	overLimit := make([]byte, maxCopyBytes+1)
+	// Create a sparse file one byte over the limit (no data written to disk).
+	big := filepath.Join(t.TempDir(), "big")
+	f, err := os.Create(big)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	_ = f.Close()
+	if err := os.Truncate(big, maxCopyBytes+1); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
 
 	res, err := handler(context.Background(), callToolReq(map[string]any{
-		"namespace": "default",
-		"pod":       "my-pod",
-		"dest_path": "/tmp/bigfile",
-		"content":   string(overLimit),
+		"namespace":  "default",
+		"pod":        "my-pod",
+		"dest_path":  "/tmp/bigfile",
+		"local_path": big,
 	}))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !res.IsError {
-		t.Fatal("expected error for oversized content")
+		t.Fatal("expected error for oversized file")
 	}
 	text := resultText(t, res)
 	if !strings.Contains(text, "exceeds") {


### PR DESCRIPTION
## Summary

Makes the pod copy tools file-to-file, like `kubectl cp`, instead of pushing file bytes through the model context.

- **`copy_to_pod`** (breaking): removes the `content`/`encoding` params. Now requires `local_path` — an absolute path to a file on the machine running the server — and streams it into the pod. Validates: absolute path, exists, is a regular file (not a directory), and within the 100 MB limit.
- **`copy_from_pod`** (additive): unchanged by default (returns contents inline, still read-only + always registered). Gains an optional `local_path` to write the pulled file straight to disk, plus an optional `overwrite` flag. When `local_path` is set the result is **metadata only** — no inline content.

### Why
Passing file contents through the LLM context is token-expensive and an unnecessary data path. File-to-file closes it while matching familiar `kubectl cp` semantics.

## Changes
- `internal/tools/cp_to_pod.go` — drop `content`/`encoding` + `decodeContent`; add `local_path` read & validation.
- `internal/tools/cp_from_pod.go` — add `local_path` + `overwrite`; write-to-disk branch returns metadata only.
- Reworked unit tests (`cp_to_pod_test.go`, `cp_from_pod_test.go`) and e2e (`e2e/cp_test.go`) to the new API.
- `README.md` — updated tool descriptions.

## Compatibility
`copy_to_pod`'s input contract changes (no more `content`). Gating is unchanged: `copy_to_pod` still requires `--allow-write`; `copy_from_pod` stays read-only/always-on. Note `copy_from_pod` can now write to an arbitrary local path when `local_path` is supplied (opt-in per call).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint` (via pre-commit) — pass
- [x] `go test ./internal/tools/...` — pass
- [x] `go vet -tags e2e ./e2e/...` — compiles
- [ ] E2E against a live cluster: `go test -tags e2e ./e2e/...` (`TestCopyToPod`, `TestCopyFromPod`)